### PR TITLE
feat: 部署管理APIの実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ AllCops:
     - "vendor/**/*"
     - "tmp/**/*"
     - "node_modules/**/*"
+    - "app/api-docs/**/*"
 
 Style/Documentation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,13 +6,13 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 3.2
   Exclude:
-    - 'db/**/*'
-    - 'config/**/*'
-    - 'script/**/*'
-    - 'bin/**/*'
-    - 'vendor/**/*'
-    - 'tmp/**/*'
-    - 'node_modules/**/*'
+    - "db/**/*"
+    - "config/**/*"
+    - "script/**/*"
+    - "bin/**/*"
+    - "vendor/**/*"
+    - "tmp/**/*"
+    - "node_modules/**/*"
 
 Style/Documentation:
   Enabled: false
@@ -37,7 +37,7 @@ RSpec/LetSetup:
 
 Metrics/BlockLength:
   Exclude:
-    - 'spec/**/*'
+    - "spec/**/*"
 
 Metrics/MethodLength:
   Max: 20
@@ -46,4 +46,10 @@ Metrics/AbcSize:
   Max: 20
 
 Layout/LineLength:
-  Max: 160 
+  Max: 160
+
+Rails/EnumHash:
+  Enabled: true
+
+Rails/EnumSyntax:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,3 +54,7 @@ Rails/EnumHash:
 
 Rails/EnumSyntax:
   Enabled: false
+
+# gemの警告を抑制
+Bundler/DuplicatedGem:
+  Enabled: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
 # ベースイメージの指定
 FROM ruby:3.2.2
 
-# 必要なパッケージのインストール
-RUN apt-get update -qq && \
-    apt-get install -y build-essential libpq-dev nodejs npm && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+# 必要なシステムパッケージのインストール
+RUN apt-get update -qq && apt-get install -y nodejs postgresql-client
 
 # 作業ディレクトリの設定
 WORKDIR /app
@@ -13,7 +10,8 @@ WORKDIR /app
 # GemfileとGemfile.lockをコピー
 COPY Gemfile Gemfile.lock ./
 
-# Bundlerのインストールと実行
+# RubyGemsを最新バージョンに更新
+RUN gem update --system
 RUN gem install bundler
 RUN bundle install
 

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :development, :test do
   gem 'rubocop', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
+  gem 'pry-byebug'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -25,11 +25,11 @@ group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'factory_bot_rails'
   gem 'faker'
+  gem 'pry-byebug'
   gem 'rspec-rails'
   gem 'rubocop', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
-  gem 'pry-byebug'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem 'rails-i18n'
 # PostgreSQLアダプター
 gem 'pg'
 
-
 gem 'rswag-api'
 gem 'rswag-ui'
 

--- a/Gemfile
+++ b/Gemfile
@@ -34,9 +34,9 @@ end
 
 group :development do
   gem 'listen', '~> 3.2'
-  gem 'web-console', '>= 3.3.0'
   gem 'rswag-api'
   gem 'rswag-ui'
+  gem 'web-console', '>= 3.3.0'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,10 @@ gem 'rails-i18n'
 # PostgreSQLアダプター
 gem 'pg'
 
+
+gem 'rswag-api'
+gem 'rswag-ui'
+
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'factory_bot_rails'
@@ -34,8 +38,6 @@ end
 
 group :development do
   gem 'listen', '~> 3.2'
-  gem 'rswag-api'
-  gem 'rswag-ui'
   gem 'web-console', '>= 3.3.0'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ end
 group :development do
   gem 'listen', '~> 3.2'
   gem 'web-console', '>= 3.3.0'
+  gem 'rswag-api'
+  gem 'rswag-ui'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
       msgpack (~> 1.2)
     builder (3.3.0)
     byebug (11.1.3)
+    coderay (1.1.3)
     concurrent-ruby (1.3.4)
     crass (1.0.6)
     database_cleaner-active_record (2.2.0)
@@ -96,8 +97,14 @@ GEM
       railties (>= 5.0.0)
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-aarch64-linux-musl)
+    ffi (1.17.0-arm-linux-gnu)
+    ffi (1.17.0-arm-linux-musl)
+    ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0-x86_64-linux-musl)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.6)
@@ -106,7 +113,7 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.9.1)
-    jwt (2.9.3)
+    jwt (2.10.1)
       base64
     language_server-protocol (3.17.0.3)
     listen (3.9.0)
@@ -125,7 +132,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.4)
     msgpack (1.7.5)
-    net-imap (0.5.3)
+    net-imap (0.5.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -135,9 +142,21 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.17.2-x86_64-darwin)
+    nokogiri (1.18.0-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.17.2-x86_64-linux)
+    nokogiri (1.18.0-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.0-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.0-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.0-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.0-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.0-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.0-x86_64-linux-musl)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.26.3)
@@ -145,6 +164,12 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.9)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
     puma (4.3.12)
       nio4r (~> 2.0)
     racc (1.8.1)
@@ -153,7 +178,7 @@ GEM
       rack (>= 2.0.0)
     rack-proxy (0.7.7)
       rack
-    rack-test (2.1.0)
+    rack-test (2.2.0)
       rack (>= 1.3)
     rails (7.0.8.7)
       actioncable (= 7.0.8.7)
@@ -191,7 +216,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    regexp_parser (2.9.3)
+    regexp_parser (2.10.0)
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
@@ -225,7 +250,7 @@ GEM
       unicode-display_width (>= 2.4.0, < 4.0)
     rubocop-ast (1.37.0)
       parser (>= 3.3.1.0)
-    rubocop-rails (2.27.0)
+    rubocop-rails (2.28.0)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.52.0, < 2.0)
@@ -253,6 +278,9 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    sqlite3 (1.7.3-aarch64-linux)
+    sqlite3 (1.7.3-arm-linux)
+    sqlite3 (1.7.3-arm64-darwin)
     sqlite3 (1.7.3-x86_64-darwin)
     sqlite3 (1.7.3-x86_64-linux)
     thor (1.3.2)
@@ -260,7 +288,7 @@ GEM
     timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (3.1.2)
+    unicode-display_width (3.1.3)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
     warden (1.2.9)
@@ -281,9 +309,16 @@ GEM
     zeitwerk (2.7.1)
 
 PLATFORMS
-  x86_64-darwin-19
-  x86_64-darwin-24
-  x86_64-linux
+  aarch64-linux
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   bootsnap (>= 1.4.2)
@@ -296,6 +331,7 @@ DEPENDENCIES
   jwt
   listen (~> 3.2)
   pg
+  pry-byebug
   puma (~> 4.1)
   rack-cors
   rails (~> 7.0.0)
@@ -316,4 +352,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.22
+   2.6.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,6 +238,12 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.2)
+    rswag-api (2.16.0)
+      activesupport (>= 5.2, < 8.1)
+      railties (>= 5.2, < 8.1)
+    rswag-ui (2.16.0)
+      actionpack (>= 5.2, < 8.1)
+      railties (>= 5.2, < 8.1)
     rubocop (1.69.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -338,6 +344,8 @@ DEPENDENCIES
   rails-i18n
   rspec-json_expectations
   rspec-rails
+  rswag-api
+  rswag-ui
   rubocop
   rubocop-rails
   rubocop-rspec

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,12 +1,28 @@
 module Api
   module V1
-    class BaseController < ApplicationController
+    class BaseController < ActionController::API
+      include Devise::Controllers::Helpers
+
       before_action :authenticate_user!
 
       private
 
-      def current_user
-        @current_user ||= User.find_by(id: doorkeeper_token&.resource_owner_id)
+      def render_success(data, status = :ok)
+        render json: data, status: status
+      end
+
+      def render_error(message, status = :unprocessable_entity)
+        render json: { error: message }, status: status
+      end
+
+      def authorize_admin!
+        return if current_user&.admin?
+
+        render_error(I18n.t('errors.messages.admin_required'), :forbidden)
+      end
+
+      def current_company
+        current_user&.company
       end
     end
   end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,23 +1,12 @@
 module Api
   module V1
     class BaseController < ApplicationController
-      protect_from_forgery with: :null_session
       before_action :authenticate_user!
 
       private
 
-      def render_success(data, status = :ok)
-        render json: data, status: status
-      end
-
-      def render_error(message, status = :unprocessable_entity)
-        render json: { errors: Array(message) }, status: status
-      end
-
-      def authorize_admin!
-        return if current_user.admin?
-
-        render_error('管理者権限が必要です', :forbidden)
+      def current_user
+        @current_user ||= User.find_by(id: doorkeeper_token&.resource_owner_id)
       end
     end
   end

--- a/app/controllers/api/v1/departments_controller.rb
+++ b/app/controllers/api/v1/departments_controller.rb
@@ -1,0 +1,60 @@
+module Api
+  module V1
+    class DepartmentsController < ApplicationController
+      before_action :authenticate_user!
+      before_action :ensure_admin
+      before_action :set_department, only: [:show, :update, :destroy]
+
+      def index
+        @departments = current_company.departments.sorted
+        render json: @departments
+      end
+
+      def show
+        render json: @department
+      end
+
+      def create
+        @department = current_company.departments.build(department_params)
+
+        if @department.save
+          render json: @department, status: :created
+        else
+          render json: { errors: @department.errors }, status: :unprocessable_entity
+        end
+      end
+
+      def update
+        if @department.update(department_params)
+          render json: @department
+        else
+          render json: { errors: @department.errors }, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        if @department.destroy
+          head :no_content
+        else
+          render json: { errors: @department.errors }, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def department_params
+        params.require(:department).permit(:name, :description)
+      end
+
+      def set_department
+        @department = current_company.departments.find(params[:id])
+      end
+
+      def ensure_admin
+        unless current_user.admin?
+          render json: { error: '権限がありません' }, status: :forbidden
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/departments_controller.rb
+++ b/app/controllers/api/v1/departments_controller.rb
@@ -1,26 +1,21 @@
 module Api
   module V1
-    class DepartmentsController < ApplicationController
-      before_action :authenticate_user!
-      before_action :ensure_admin
-      before_action :set_department, only: [:show, :update, :destroy]
+    class DepartmentsController < BaseController
+      before_action :set_company
+      before_action :set_department, only: %i[update destroy]
+      before_action :authorize_admin!
 
       def index
-        @departments = current_company.departments.sorted
+        @departments = @company.departments
         render json: @departments
       end
 
-      def show
-        render json: @department
-      end
-
       def create
-        @department = current_company.departments.build(department_params)
-
+        @department = @company.departments.build(department_params)
         if @department.save
           render json: @department, status: :created
         else
-          render json: { errors: @department.errors }, status: :unprocessable_entity
+          render json: { errors: @department.errors.full_messages }, status: :unprocessable_entity
         end
       end
 
@@ -28,32 +23,37 @@ module Api
         if @department.update(department_params)
           render json: @department
         else
-          render json: { errors: @department.errors }, status: :unprocessable_entity
+          render json: { errors: @department.errors.full_messages }, status: :unprocessable_entity
         end
       end
 
       def destroy
-        if @department.destroy
-          head :no_content
+        if @department.users.exists?
+          render json: { errors: ['所属しているユーザーが存在するため削除できません'] }, status: :unprocessable_entity
         else
-          render json: { errors: @department.errors }, status: :unprocessable_entity
+          @department.destroy
+          head :no_content
         end
       end
 
       private
 
+      def set_company
+        @company = Company.find(params[:company_id])
+      end
+
+      def set_department
+        @department = @company.departments.find(params[:id])
+      end
+
       def department_params
         params.require(:department).permit(:name, :description)
       end
 
-      def set_department
-        @department = current_company.departments.find(params[:id])
-      end
+      def authorize_admin!
+        return if current_user&.admin?
 
-      def ensure_admin
-        unless current_user.admin?
-          render json: { error: '権限がありません' }, status: :forbidden
-        end
+        render json: { error: '権限がありません' }, status: :forbidden
       end
     end
   end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -6,7 +6,7 @@ module Api
       before_action :authorize_admin!, only: %i[create update]
 
       def index
-        users = @company.users.includes(:company)
+        users = @company.users.includes(:department)
         render_success(users)
       end
 
@@ -19,6 +19,7 @@ module Api
         if user.save
           render_success(user, :created)
         else
+          Rails.logger.error("User creation failed: #{user.errors.full_messages}")
           render_error(user.errors.full_messages)
         end
       end
@@ -27,6 +28,7 @@ module Api
         if @user.update(user_params)
           render_success(@user)
         else
+          Rails.logger.error("User update failed: #{@user.errors.full_messages}")
           render_error(@user.errors.full_messages)
         end
       end
@@ -42,13 +44,7 @@ module Api
       end
 
       def user_params
-        params.require(:user).permit(:email, :password, :role)
-      end
-
-      def authorize_admin!
-        return if current_user.admin?
-
-        render_error('管理者権限が必要です', :forbidden)
+        params.require(:user).permit(:email, :password, :role, :department_id)
       end
     end
   end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,5 +1,6 @@
 class Company < ApplicationRecord
   has_many :users, dependent: :destroy
+  has_many :departments, dependent: :destroy
 
   validates :company_name, presence: true
   validates :phone_number, presence: true

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -1,0 +1,22 @@
+class Department < ApplicationRecord
+  belongs_to :company
+  has_many :users, dependent: :restrict_with_error
+
+  validates :name,
+            presence: true,
+            uniqueness: { scope: :company_id },
+            length: { maximum: 50 }
+  validates :description, length: { maximum: 500 }
+
+  scope :sorted, -> { order(:name) }
+
+  validate :ensure_no_users_before_destroy, on: :destroy
+
+  private
+
+  def ensure_no_users_before_destroy
+    if users.exists?
+      errors.add(:base, 'ユーザーが所属している部署は削除できません')
+    end
+  end
+end

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -15,8 +15,8 @@ class Department < ApplicationRecord
   private
 
   def ensure_no_users_before_destroy
-    if users.exists?
-      errors.add(:base, 'ユーザーが所属している部署は削除できません')
-    end
+    return unless users.exists?
+
+    errors.add(:base, 'ユーザーが所属している部署は削除できません')
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   belongs_to :company
+  belongs_to :department, optional: true
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
@@ -7,4 +8,11 @@ class User < ApplicationRecord
   enum :role, { admin: 0, user: 1 }
 
   validates :role, presence: true
+  validates :department, presence: true, if: :require_department?
+
+  private
+
+  def require_department?
+    role != 'admin'
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,10 @@ class User < ApplicationRecord
   validates :role, presence: true
   validates :department, presence: true, if: :require_department?
 
+  def admin?
+    role == 'admin'
+  end
+
   private
 
   def require_department?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,18 +5,10 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  enum :role, { admin: 0, user: 1 }
+  enum role: { admin: 0, user: 1 }
 
+  validates :email, presence: true
+  validates :password, presence: true, on: :create
   validates :role, presence: true
-  validates :department, presence: true, if: :require_department?
-
-  def admin?
-    role == 'admin'
-  end
-
-  private
-
-  def require_department?
-    role != 'admin'
-  end
+  validates :department, presence: true, unless: :admin?
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,5 +18,11 @@ module Stock2
     config.i18n.default_locale = :ja
 
     config.hosts << "www.example.com"
+
+    config.generators do |g|
+      g.test_framework :rspec
+      g.helper_specs false
+      g.controller_specs false
+    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,5 +16,7 @@ module Stock2
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
     config.i18n.default_locale = :ja
+
+    config.hosts << "www.example.com"
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,4 +46,8 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+
+  config.hosts.clear
+  config.hosts << "www.example.com"
+  config.hosts << "localhost"
 end

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,3 @@
+Rswag::Api.configure do |c|
+  c.openapi_root = Rails.root.join('swagger').to_s
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,0 +1,3 @@
+Rswag::Ui.configure do |c|
+  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,3 +1,3 @@
 Rswag::Ui.configure do |c|
-  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+  c.openapi_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,8 @@
+ja:
+  errors:
+    messages:
+      admin_required: "管理者権限が必要です"
+  departments:
+    destroy:
+      errors:
+        users_exist: "所属しているユーザーが存在するため削除できません"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :companies, only: [:index, :show, :create, :update] do
+        resources :departments, only: [:index, :show, :create, :update, :destroy]
         resources :users, only: [:index, :show, :create, :update]
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => '/api-docs'
+  mount Rswag::Api::Engine => '/api-docs'
   devise_for :users
 
   get 'health', to: 'health_check#index'

--- a/db/migrate/20241222154413_create_initial_tables.rb
+++ b/db/migrate/20241222154413_create_initial_tables.rb
@@ -1,30 +1,23 @@
 class CreateInitialTables < ActiveRecord::Migration[7.0]
   def change
-    # 企業テーブル
     create_table :companies do |t|
       t.string :company_name, null: false
       t.text :address
       t.string :phone_number
       t.string :subdomain, null: false
-      
+
       t.timestamps
     end
 
     add_index :companies, :subdomain, unique: true
 
-    # ユーザーテーブル
     create_table :users do |t|
-      ## Database authenticatable
       t.string :email, null: false, default: ""
       t.string :encrypted_password, null: false, default: ""
       t.references :company, null: false, foreign_key: true
       t.integer :role, default: 1  # 1 = user（デフォルト値）
-
-      ## Recoverable
       t.string :reset_password_token
       t.datetime :reset_password_sent_at
-
-      ## Rememberable
       t.datetime :remember_created_at
 
       t.timestamps null: false

--- a/db/migrate/20241225143542_create_departments.rb
+++ b/db/migrate/20241225143542_create_departments.rb
@@ -1,0 +1,13 @@
+class CreateDepartments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :departments do |t|
+      t.string :name, null: false
+      t.text :description
+      t.references :company, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :departments, %i[company_id name], unique: true
+  end
+end

--- a/db/migrate/20241225143717_add_department_to_users.rb
+++ b/db/migrate/20241225143717_add_department_to_users.rb
@@ -1,0 +1,5 @@
+class AddDepartmentToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :users, :department, foreign_key: true
+  end
+end

--- a/db/migrate/20241225145728_add_name_to_users.rb
+++ b/db/migrate/20241225145728_add_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddNameToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :name, :string, null: false
+  end
+end

--- a/db/migrate/20241225145728_add_name_to_users.rb
+++ b/db/migrate/20241225145728_add_name_to_users.rb
@@ -1,5 +1,5 @@
 class AddNameToUsers < ActiveRecord::Migration[7.0]
   def change
-    add_column :users, :name, :string, null: false
+    add_column :users, :name, :string, null: false, default: ''
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_25_143717) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_25_145728) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -45,6 +45,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_25_143717) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "department_id"
+    t.string "name"
     t.index ["company_id"], name: "index_users_on_company_id"
     t.index ["department_id"], name: "index_users_on_department_id"
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_22_154413) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_25_143717) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -24,6 +24,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_22_154413) do
     t.index ["subdomain"], name: "index_companies_on_subdomain", unique: true
   end
 
+  create_table "departments", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "description"
+    t.bigint "company_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["company_id", "name"], name: "index_departments_on_company_id_and_name", unique: true
+    t.index ["company_id"], name: "index_departments_on_company_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -34,10 +44,14 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_22_154413) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "department_id"
     t.index ["company_id"], name: "index_users_on_company_id"
+    t.index ["department_id"], name: "index_users_on_department_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "departments", "companies"
   add_foreign_key "users", "companies"
+  add_foreign_key "users", "departments"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -45,7 +45,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_25_145728) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "department_id"
-    t.string "name"
+    t.string "name", default: "", null: false
     t.index ["company_id"], name: "index_users_on_company_id"
     t.index ["department_id"], name: "index_users_on_department_id"
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,9 @@ services:
       POSTGRES_PASSWORD: password
     depends_on:
       - db
+    tty: true
+    stdin_open: true
 
 volumes:
   postgres_data:
-  bundle_data: 
+  bundle_data:

--- a/spec/factories/departments.rb
+++ b/spec/factories/departments.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :department do
+    sequence(:name) { |n| "部署#{n}" }
+    description { "部署の説明文です" }
+    association :company
+  end
+end

--- a/spec/factories/departments.rb
+++ b/spec/factories/departments.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :department do
     sequence(:name) { |n| "部署#{n}" }
-    description { "部署の説明文です" }
+    description { '部署の説明文です' }
     association :company
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,12 +1,14 @@
 FactoryBot.define do
   factory :user do
-    email { Faker::Internet.unique.email }
-    password { 'password123' }
-    role { 1 }
+    sequence(:email) { |n| "user#{n}@example.com" }
+    password { 'password' }
+    role { :user }
     association :company
+    association :department
 
     trait :admin do
-      role { 0 }
+      role { :admin }
+      department { nil }
     end
   end
 end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Company, type: :model do
   describe 'バリデーション' do
-    it '会社名が必須であること' do
+    it '企業名が必須であること' do
       company = described_class.new(company_name: nil)
       company.valid?
       expect(company.errors[:company_name]).to include('を入力してください')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,6 +2,9 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   describe 'バリデーション' do
+    let(:company) { create(:company) }
+    let(:department) { create(:department, company: company) }
+
     it 'メールアドレスが必須であること' do
       user = described_class.new(email: nil)
       user.valid?
@@ -21,15 +24,38 @@ RSpec.describe User, type: :model do
     end
 
     it 'ロールが適切な値であること' do
-      user = described_class.new
-      expect(user).to define_enum_for(:role).with_values(%i[admin user])
+      expect(described_class.roles).to eq({ 'admin' => 0, 'user' => 1 })
+    end
+
+    context '一般ユーザーの場合' do
+      it '部署が必須であること' do
+        user = build(:user, role: :user, department: nil, company: company)
+        user.valid?
+        expect(user.errors[:department]).to include('を入力してください')
+      end
+    end
+
+    context '管理者の場合' do
+      it '部署が任意であること' do
+        user = build(:user, :admin, department: nil, company: company)
+        expect(user).to be_valid
+      end
     end
   end
 
   describe '関連付け' do
-    it '企業に所属すること' do
-      user = described_class.new
-      expect(user).to belong_to(:company)
+    context '一般ユーザーの場合' do
+      subject { build(:user, company: create(:company), department: create(:department)) }
+
+      it { is_expected.to belong_to(:company) }
+      it { is_expected.to belong_to(:department) }
+    end
+
+    context '管理者の場合' do
+      subject { build(:user, :admin, company: create(:company), department: nil) }
+
+      it { is_expected.to belong_to(:company) }
+      it { is_expected.to belong_to(:department).optional }
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,8 +61,9 @@ RSpec.configure do |config|
   # FactoryBotのメソッドを直接使用可能にする
   config.include FactoryBot::Syntax::Methods
 
-  config.before(:each, type: :request) do
-    Rails.logger = Logger.new($stdout)
-    Rails.logger.level = :debug
-  end
+  # ログレベルを:debugに設定
+  # config.before(:each, type: :request) do
+  #   Rails.logger = Logger.new($stdout)
+  #   Rails.logger.level = :debug
+  # end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
+require 'shoulda/matchers'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
@@ -19,6 +20,14 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = Rails.root.join('spec/fixtures').to_s
@@ -51,4 +60,9 @@ RSpec.configure do |config|
 
   # FactoryBotのメソッドを直接使用可能にする
   config.include FactoryBot::Syntax::Methods
+
+  config.before(:each, type: :request) do
+    Rails.logger = Logger.new($stdout)
+    Rails.logger.level = :debug
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -52,11 +52,3 @@ RSpec.configure do |config|
   # FactoryBotのメソッドを直接使用可能にする
   config.include FactoryBot::Syntax::Methods
 end
-
-# Shoulda Matchersの設定
-Shoulda::Matchers.configure do |config|
-  config.integrate do |with|
-    with.test_framework :rspec
-    with.library :rails
-  end
-end

--- a/spec/requests/api/v1/companies_spec.rb
+++ b/spec/requests/api/v1/companies_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Api::V1::Companies', type: :request do
+  before do
+    host! 'localhost'
+  end
+
   let(:company) { create(:company) }
   let(:admin) { create(:user, :admin, company: company) }
   let(:user) { create(:user, company: company) }
@@ -16,7 +20,7 @@ RSpec.describe 'Api::V1::Companies', type: :request do
       it '企業一覧を取得できること' do
         get api_v1_companies_path
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body.size).to eq 4
+        expect(response.parsed_body.size).to eq 5
       end
     end
   end

--- a/spec/requests/api/v1/departments_spec.rb
+++ b/spec/requests/api/v1/departments_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Departments', type: :request do
+  let(:company) { create(:company) }
+  let(:admin) { create(:user, :admin, company: company, role: 'admin') }
+  let(:user) { create(:user, company: company) }
+  let(:department) { create(:department, company: company) }
+
+  describe 'GET /api/v1/companies/:company_id/departments' do
+    context '管理者の場合' do
+      before do
+        host! 'localhost'
+        sign_in admin
+        create_list(:department, 3, company: company)
+        get "/api/v1/companies/#{company.id}/departments"
+      end
+
+      it '200を返すこと' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it '全ての部署を返すこと' do
+        expect(json.size).to eq(3)
+      end
+    end
+
+    context '一般ユーザーの場合' do
+      before do
+        host! 'localhost'
+        sign_in user
+        get "/api/v1/companies/#{company.id}/departments"
+      end
+
+      it '403を返すこと' do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  private
+
+  def json
+    response.parsed_body
+  end
+end

--- a/spec/requests/api/v1/departments_spec.rb
+++ b/spec/requests/api/v1/departments_spec.rb
@@ -6,6 +6,14 @@ RSpec.describe 'Api::V1::Departments', type: :request do
   let(:user) { create(:user, company: company) }
   let(:department) { create(:department, company: company) }
 
+  def valid_params
+    { department: { name: '新しい部署' } }
+  end
+
+  def invalid_params
+    { department: { name: '' } }
+  end
+
   describe 'GET /api/v1/companies/:company_id/departments' do
     context '管理者の場合' do
       before do
@@ -29,6 +37,114 @@ RSpec.describe 'Api::V1::Departments', type: :request do
         host! 'localhost'
         sign_in user
         get "/api/v1/companies/#{company.id}/departments"
+      end
+
+      it '403を返すこと' do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe 'POST /api/v1/companies/:company_id/departments' do
+    context '管理者の場合' do
+      before do
+        host! 'localhost'
+        sign_in admin
+      end
+
+      context '有効なパラメータの場合' do
+        it '部署を作成できること' do
+          expect do
+            post "/api/v1/companies/#{company.id}/departments", params: valid_params
+          end.to change(Department, :count).by(1)
+          expect(response).to have_http_status(:created)
+        end
+      end
+
+      context '無効なパラメータの場合' do
+        it '部署を作成できないこと' do
+          expect do
+            post "/api/v1/companies/#{company.id}/departments", params: invalid_params
+          end.not_to change(Department, :count)
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+
+    context '一般ユーザーの場合' do
+      before do
+        host! 'localhost'
+        sign_in user
+        post "/api/v1/companies/#{company.id}/departments", params: valid_params
+      end
+
+      it '403を返すこと' do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe 'PATCH /api/v1/companies/:company_id/departments/:id' do
+    context '管理者の場合' do
+      before do
+        host! 'localhost'
+        sign_in admin
+      end
+
+      context '有効なパラメータの場合' do
+        it '部署を更新できること' do
+          patch "/api/v1/companies/#{company.id}/departments/#{department.id}",
+                params: valid_params
+          expect(response).to have_http_status(:ok)
+          expect(department.reload.name).to eq('新しい部署')
+        end
+      end
+
+      context '無効なパラメータの場合' do
+        it '部署を更新できないこと' do
+          patch "/api/v1/companies/#{company.id}/departments/#{department.id}",
+                params: invalid_params
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(department.reload.name).not_to eq('')
+        end
+      end
+    end
+
+    context '一般ユーザーの場合' do
+      before do
+        host! 'localhost'
+        sign_in user
+        patch "/api/v1/companies/#{company.id}/departments/#{department.id}",
+              params: valid_params
+      end
+
+      it '403を返すこと' do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe 'DELETE /api/v1/companies/:company_id/departments/:id' do
+    context '管理者の場合' do
+      before do
+        host! 'localhost'
+        sign_in admin
+      end
+
+      it '部署を削除できること' do
+        department # 事前に部署を作成
+        expect do
+          delete "/api/v1/companies/#{company.id}/departments/#{department.id}"
+        end.to change(Department, :count).by(-1)
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context '一般ユーザーの場合' do
+      before do
+        host! 'localhost'
+        sign_in user
+        delete "/api/v1/companies/#{company.id}/departments/#{department.id}"
       end
 
       it '403を返すこと' do

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'HealthCheck', type: :request do
       it '200 OKを返すこと' do
         get '/health'
         expect(response).to have_http_status(:ok)
-        expect(JSON.parse(response.body)).to eq({ 'status' => 'ok' })
+        expect(response.parsed_body).to eq({ 'status' => 'ok' })
       end
     end
 
@@ -18,7 +18,7 @@ RSpec.describe 'HealthCheck', type: :request do
       it '503 Service Unavailableを返すこと' do
         get '/health'
         expect(response).to have_http_status(:service_unavailable)
-        expect(JSON.parse(response.body)['status']).to eq('error')
+        expect(response.parsed_body['status']).to eq('error')
       end
     end
   end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  title: Company Management API
+  title: 企業管理API
   version: v1
   description: |
     Company Management System API documentation
@@ -34,7 +34,7 @@ components:
       name: company_id
       in: path
       required: true
-      description: 会社ID
+      description: 企業ID
       schema:
         type: integer
         minimum: 1
@@ -95,7 +95,7 @@ components:
           maxLength: 500
         company_id:
           type: integer
-          description: 所属会社ID
+          description: 所属企業ID
         created_at:
           type: string
           format: date-time
@@ -136,16 +136,16 @@ components:
           items:
             type: string
 
-    # 会社のスキーマ
+    # 企業のスキーマ
     Company:
       type: object
       properties:
         id:
           type: integer
-          description: 会社ID
+          description: 企業ID
         company_name:
           type: string
-          description: 会社名
+          description: 企業名
         address:
           type: string
           description: 住所
@@ -174,7 +174,7 @@ components:
           properties:
             company_name:
               type: string
-              description: 会社名
+              description: 企業名
             address:
               type: string
               description: 住所
@@ -208,7 +208,7 @@ components:
           description: ユーザー権限
         company_id:
           type: integer
-          description: 所属会社ID
+          description: 所属企業ID
         department_id:
           type: integer
           description: 所属部署ID
@@ -263,7 +263,7 @@ paths:
         - Departments
       summary: 部署一覧の取得
       description: |
-        指定した会社の部署一覧を取得します。
+        指定した企業の部署一覧を取得します。
         管理者のみがアクセス可能です。
       security:
         - bearer_auth: []
@@ -293,7 +293,7 @@ paths:
       description: |
         新しい部署を作成します。
         - 管理者のみが実行可能です
-        - 部署名は会社内で一意である必要が��ります
+        - 部署名は企業内で一意である必要がります
         - 部署名は50文字以内です
       security:
         - bearer_auth: []
@@ -348,7 +348,7 @@ paths:
       description: |
         部署の情報を更新します。
         - 管理者のみが実行可能です
-        - 部署名は会社内で一意である必要があります
+        - 部署名は企業内で一意である必要があります
         - 部署名は50文字以内です
       security:
         - bearer_auth: []
@@ -390,18 +390,18 @@ paths:
               example:
                 errors: ["所属しているユーザーが存在するため削除できません"]
 
-  # 会社関連のエンドポイント
+  # 企業関連のエンドポイント
   /api/v1/companies:
     get:
       tags:
         - Companies
-      summary: 会社一覧の取得
-      description: 全ての会社の一覧を取得します
+      summary: 企業一覧の取得
+      description: 全ての企業の一覧を取得します
       security:
         - bearer_auth: []
       responses:
         "200":
-          description: 会社一覧の取得に成功
+          description: 企業一覧の取得に成功
           content:
             application/json:
               schema:
@@ -412,9 +412,9 @@ paths:
     post:
       tags:
         - Companies
-      summary: 会社の新規作成
+      summary: 企業の新規作成
       description: |
-        新しい会社を作成します。
+        新しい企業を作成します。
         - 管理者のみが実行可能です
         - サブドメインは一意である必要があります
       security:
@@ -427,7 +427,7 @@ paths:
               $ref: "#/components/schemas/CompanyInput"
       responses:
         "201":
-          description: 会社の作成に成功
+          description: 企業の作成に成功
           content:
             application/json:
               schema:
@@ -440,7 +440,7 @@ paths:
       - name: id
         in: path
         required: true
-        description: 会社ID
+        description: 企業ID
         schema:
           type: integer
           minimum: 1
@@ -448,12 +448,12 @@ paths:
     get:
       tags:
         - Companies
-      summary: 会社詳細の取得
+      summary: 企業詳細の取得
       security:
         - bearer_auth: []
       responses:
         "200":
-          description: 会社詳細の取得に成功
+          description: 企業詳細の取得に成功
           content:
             application/json:
               schema:
@@ -464,9 +464,9 @@ paths:
     patch:
       tags:
         - Companies
-      summary: 会社情報の更新
+      summary: 企業情報の更新
       description: |
-        会社の情報を更新します。
+        企業の情報を更新します。
         - 管理者のみが実行可能です
       security:
         - bearer_auth: []
@@ -478,7 +478,7 @@ paths:
               $ref: "#/components/schemas/CompanyInput"
       responses:
         "200":
-          description: 会社情報の更新に成功
+          description: 企業情報の更新に成功
           content:
             application/json:
               schema:
@@ -495,7 +495,7 @@ paths:
       tags:
         - Users
       summary: ユーザー一覧の取得
-      description: 指定した会社のユーザー一覧を取得します
+      description: 指定した企業のユーザー一覧を取得します
       security:
         - bearer_auth: []
       responses:

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,0 +1,590 @@
+openapi: 3.0.1
+info:
+  title: Company Management API
+  version: v1
+  description: |
+    Company Management System API documentation
+
+    ## 認証について
+    すべてのAPIエンドポイントはJWTトークンによる認証が必要です。
+    トークンは`Authorization`ヘッダーに`Bearer <token>`の形式で指定してください。
+
+    ## エラーレスポンス
+    - 401: 認証エラー
+    - 403: 権限エラー
+    - 404: リソースが見つからない
+    - 422: バリデーションエラー
+
+servers:
+  - url: http://localhost:3000
+    description: Development server
+
+components:
+  # 認証スキーマ
+  securitySchemes:
+    bearer_auth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: JWTトークンをAuthorizationヘッダーに指定してください
+
+  # 共通パラメータ
+  parameters:
+    CompanyId:
+      name: company_id
+      in: path
+      required: true
+      description: 会社ID
+      schema:
+        type: integer
+        minimum: 1
+
+    DepartmentId:
+      name: id
+      in: path
+      required: true
+      description: 部署ID
+      schema:
+        type: integer
+        minimum: 1
+
+  # 共通レスポンス
+  responses:
+    Forbidden:
+      description: 権限エラー
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error: "権限がありません"
+
+    NotFound:
+      description: リソースが見つかりません
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error: "リソースが見つかりません"
+
+    UnprocessableEntity:
+      description: バリデーションエラー
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            errors: ["バリデーションエラーが発生しました"]
+
+  # スキーマ定義
+  schemas:
+    Department:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: 部署ID
+        name:
+          type: string
+          description: 部署名
+          maxLength: 50
+        description:
+          type: string
+          description: 部署の説明
+          maxLength: 500
+        company_id:
+          type: integer
+          description: 所属会社ID
+        created_at:
+          type: string
+          format: date-time
+          description: 作成日時
+        updated_at:
+          type: string
+          format: date-time
+          description: 更新日時
+      required:
+        - id
+        - name
+        - company_id
+
+    DepartmentInput:
+      type: object
+      properties:
+        department:
+          type: object
+          properties:
+            name:
+              type: string
+              description: 部署名
+              maxLength: 50
+            description:
+              type: string
+              description: 部署の説明
+              maxLength: 500
+          required:
+            - name
+
+    Error:
+      type: object
+      properties:
+        error:
+          type: string
+        errors:
+          type: array
+          items:
+            type: string
+
+    # 会社のスキーマ
+    Company:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: 会社ID
+        company_name:
+          type: string
+          description: 会社名
+        address:
+          type: string
+          description: 住所
+        phone_number:
+          type: string
+          description: 電話番号
+        subdomain:
+          type: string
+          description: サブドメイン
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - company_name
+        - subdomain
+
+    CompanyInput:
+      type: object
+      properties:
+        company:
+          type: object
+          properties:
+            company_name:
+              type: string
+              description: 会社名
+            address:
+              type: string
+              description: 住所
+            phone_number:
+              type: string
+              description: 電話番号
+            subdomain:
+              type: string
+              description: サブドメイン
+          required:
+            - company_name
+            - subdomain
+
+    # ユーザーのスキーマ
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: ユーザーID
+        email:
+          type: string
+          format: email
+          description: メールアドレス
+        name:
+          type: string
+          description: ユーザー名
+        role:
+          type: string
+          enum: [admin, user]
+          description: ユーザー権限
+        company_id:
+          type: integer
+          description: 所属会社ID
+        department_id:
+          type: integer
+          description: 所属部署ID
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - email
+        - role
+        - company_id
+
+    UserInput:
+      type: object
+      properties:
+        user:
+          type: object
+          properties:
+            email:
+              type: string
+              format: email
+              description: メールアドレス
+            password:
+              type: string
+              description: パスワード
+            name:
+              type: string
+              description: ユーザー名
+            role:
+              type: string
+              enum: [admin, user]
+              description: ユーザー権限
+            department_id:
+              type: integer
+              description: 所属部署ID
+          required:
+            - email
+            - password
+            - role
+
+# APIパス定義
+paths:
+  /api/v1/companies/{company_id}/departments:
+    parameters:
+      - $ref: "#/components/parameters/CompanyId"
+
+    get:
+      tags:
+        - Departments
+      summary: 部署一覧の取得
+      description: |
+        指定した会社の部署一覧を取得します。
+        管理者のみがアクセス可能です。
+      security:
+        - bearer_auth: []
+      responses:
+        "200":
+          description: 部署一覧の取得に成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Department"
+              example:
+                - id: 1
+                  name: "営業部"
+                  description: "営業部門です"
+                  company_id: 1
+                  created_at: "2024-01-01T00:00:00.000Z"
+                  updated_at: "2024-01-01T00:00:00.000Z"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+    post:
+      tags:
+        - Departments
+      summary: 部署の新規作成
+      description: |
+        新しい部署を作成します。
+        - 管理者のみが実行可能です
+        - 部署名は会社内で一意である必要が��ります
+        - 部署名は50文字以内です
+      security:
+        - bearer_auth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DepartmentInput"
+            example:
+              department:
+                name: "新規部署"
+                description: "新規部署の説明"
+      responses:
+        "201":
+          description: 部署の作成に成功
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Department"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /api/v1/companies/{company_id}/departments/{id}:
+    parameters:
+      - $ref: "#/components/parameters/CompanyId"
+      - $ref: "#/components/parameters/DepartmentId"
+
+    get:
+      tags:
+        - Departments
+      summary: 部署詳細の取得
+      description: 指定した部署の詳細情報を取得します
+      security:
+        - bearer_auth: []
+      responses:
+        "200":
+          description: 部署詳細の取得に成功
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Department"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    patch:
+      tags:
+        - Departments
+      summary: 部署情報の更新
+      description: |
+        部署の情報を更新します。
+        - 管理者のみが実行可能です
+        - 部署名は会社内で一意である必要があります
+        - 部署名は50文字以内です
+      security:
+        - bearer_auth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DepartmentInput"
+      responses:
+        "200":
+          description: 部署の更新に成功
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Department"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
+
+    delete:
+      tags:
+        - Departments
+      summary: 部署の削除
+      description: |
+        部署を削除します。
+        - 管理者のみが実行可能です
+        - 所属するユーザーがいる場合は削除できません
+      security:
+        - bearer_auth: []
+      responses:
+        "204":
+          description: 部署の削除に成功
+        "422":
+          description: 削除できない部署
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                errors: ["所属しているユーザーが存在するため削除できません"]
+
+  # 会社関連のエンドポイント
+  /api/v1/companies:
+    get:
+      tags:
+        - Companies
+      summary: 会社一覧の取得
+      description: 全ての会社の一覧を取得します
+      security:
+        - bearer_auth: []
+      responses:
+        "200":
+          description: 会社一覧の取得に成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Company"
+
+    post:
+      tags:
+        - Companies
+      summary: 会社の新規作成
+      description: |
+        新しい会社を作成します。
+        - 管理者のみが実行可能です
+        - サブドメインは一意である必要があります
+      security:
+        - bearer_auth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CompanyInput"
+      responses:
+        "201":
+          description: 会社の作成に成功
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Company"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
+
+  /api/v1/companies/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: 会社ID
+        schema:
+          type: integer
+          minimum: 1
+
+    get:
+      tags:
+        - Companies
+      summary: 会社詳細の取得
+      security:
+        - bearer_auth: []
+      responses:
+        "200":
+          description: 会社詳細の取得に成功
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Company"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    patch:
+      tags:
+        - Companies
+      summary: 会社情報の更新
+      description: |
+        会社の情報を更新します。
+        - 管理者のみが実行可能です
+      security:
+        - bearer_auth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CompanyInput"
+      responses:
+        "200":
+          description: 会社情報の更新に成功
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Company"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
+
+  # ユーザー関連のエンドポイント
+  /api/v1/companies/{company_id}/users:
+    parameters:
+      - $ref: "#/components/parameters/CompanyId"
+
+    get:
+      tags:
+        - Users
+      summary: ユーザー一覧の取得
+      description: 指定した会社のユーザー一覧を取得します
+      security:
+        - bearer_auth: []
+      responses:
+        "200":
+          description: ユーザー一覧の取得に成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/User"
+
+    post:
+      tags:
+        - Users
+      summary: ユーザーの新規作成
+      description: |
+        新しいユーザーを作成します。
+        - 管理者のみが実行可能です
+        - メールアドレスは一意である必要があります
+        - 一般ユーザーは部署の所属が必須です
+      security:
+        - bearer_auth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserInput"
+      responses:
+        "201":
+          description: ユーザーの作成に成功
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
+
+  /api/v1/companies/{company_id}/users/{id}:
+    parameters:
+      - $ref: "#/components/parameters/CompanyId"
+      - name: id
+        in: path
+        required: true
+        description: ユーザーID
+        schema:
+          type: integer
+          minimum: 1
+
+    get:
+      tags:
+        - Users
+      summary: ユーザー詳細の取得
+      security:
+        - bearer_auth: []
+      responses:
+        "200":
+          description: ユーザー詳細の取得に成功
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    patch:
+      tags:
+        - Users
+      summary: ユーザー情報の更新
+      description: |
+        ユーザーの情報を更新します。
+        - 管理者のみが実行可能です
+        - メールアドレスは一意である必要があります
+        - 一般ユーザーは部署の所属が必須です
+      security:
+        - bearer_auth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserInput"
+      responses:
+        "200":
+          description: ユーザー情報の更新に成功
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"


### PR DESCRIPTION
# 部署管理APIの実装

## 変更内容
1. 企業管理API
   - 部署一覧取得 (GET /api/v1/departments)
   - 部署作成 (POST /api/v1/departments)
   - 部署更新 (PATCH /api/v1/departments/:id)
   - 部署削除(DELETE /api/v1/departments/:id)

2. テストの追加
   - 部署管理APIのテスト

3. ドキュメントの追加
  - 部署管理APIのドキュメント
  - 企業管理APIのドキュメント
  - ユーザー管理APIのドキュメント

## その他
- テストが全て成功することを確認済み