### PR TITLE
feat: カテゴリ管理機能の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,22 @@ git push origin feature/new-feature
 - RSpecテストの実行
 
 ## APIドキュメント
-※ 別途作成予定
+APIドキュメントはSwagger UIで確認できます。
+
+### 確認方法
+1. 開発サーバーを起動
+```bash
+docker-compose up
+```
+
+2. ブラウザでSwagger UIにアクセス
+```
+http://localhost:3000/api-docs
+```
+
+### 認証について
+すべてのAPIエンドポイントはJWTトークンによる認証が必要です。
+トークンは`Authorization`ヘッダーに`Bearer <token>`の形式で指定してください。
 
 ## 本番環境
 
@@ -114,3 +129,22 @@ docker-compose -f docker-compose.production.yml exec web rails db:create db:migr
 3. 監視
    - ヘルスチェックエンドポイントでアプリケーションの状態を監視
    - ログは標準出力に出力され、コンテナログとして収集可能
+
+### エラーレスポンス
+すべてのAPIは以下の形式でエラーを返します：
+```json
+{
+  "error": "エラーメッセージ",
+  "errors": ["詳細なエラーメッセージ1", "詳細なエラーメッセージ2"]
+}
+```
+
+### ステータスコード
+- 200: 成功
+- 201: 作成成功
+- 204: 削除成功
+- 401: 認証エラー
+- 403: 権限エラー
+- 404: リソースが見つからない
+- 422: バリデーションエラー
+- 500: サーバーエラー

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -1,0 +1,58 @@
+module Api
+  module V1
+    class CategoriesController < BaseController
+      before_action :authorize_admin!, except: %i[index show]
+      before_action :set_category, only: %i[show update destroy]
+
+      def index
+        @categories = current_company.categories
+        render json: @categories.as_json
+      rescue StandardError => _e
+        render_error(['予期せぬエラーが発生しました'], :internal_server_error)
+      end
+
+      def show
+        render json: @category.as_json
+      end
+
+      def create
+        @category = current_company.categories.build(category_params)
+        if @category.save
+          render json: @category, status: :created
+        else
+          Rails.logger.error "Category creation failed: #{@category.errors.full_messages.join(', ')}"
+          render_error(@category.errors.full_messages, :unprocessable_entity)
+        end
+      end
+
+      def update
+        if @category.update(category_params)
+          render json: @category
+        else
+          Rails.logger.error "Category update failed: #{@category.errors.full_messages.join(', ')}"
+          render_error(@category.errors.full_messages, :unprocessable_entity)
+        end
+      end
+
+      def destroy
+        @category.destroy
+        head :no_content
+      rescue StandardError => e
+        Rails.logger.error "Category deletion failed: #{e.message}"
+        render_error(['カテゴリーの削除に失敗しました'], :unprocessable_entity)
+      end
+
+      private
+
+      def category_params
+        params.require(:category).permit(:name, :description)
+      end
+
+      def set_category
+        @category = current_company.categories.find(params[:id])
+      rescue ActiveRecord::RecordNotFound
+        render_error('カテゴリが見つかりません', :not_found)
+      end
+    end
+  end
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,11 @@
+class Category < ApplicationRecord
+  belongs_to :company
+
+  validates :name,
+            presence: true,
+            uniqueness: { scope: :company_id },
+            length: { maximum: 50 }
+  validates :description, length: { maximum: 500 }
+
+  scope :sorted, -> { order(:name) }
+end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,6 +1,7 @@
 class Company < ApplicationRecord
   has_many :users, dependent: :destroy
   has_many :departments, dependent: :destroy
+  has_many :categories, dependent: :destroy
 
   validates :company_name, presence: true
   validates :phone_number, presence: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,9 +7,12 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :companies, only: [:index, :show, :create, :update] do
-        resources :departments, only: [:index, :show, :create, :update, :destroy]
-        resources :users, only: [:index, :show, :create, :update]
+      resources :companies, only: %i[index show create update] do
+        resources :departments, only: %i[index show create update destroy]
+        resources :users, only: %i[index show create update]
+      end
+      resources :companies do
+        resources :categories, only: %i[index show create update destroy]
       end
     end
   end

--- a/db/migrate/20241228141233_create_categories.rb
+++ b/db/migrate/20241228141233_create_categories.rb
@@ -1,0 +1,13 @@
+class CreateCategories < ActiveRecord::Migration[7.0]
+  def change
+    create_table :categories do |t|
+      t.string :name, null: false
+      t.text :description
+      t.references :company, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :categories, [:company_id, :name], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,11 +15,12 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_28_141233) do
   enable_extension "plpgsql"
 
   create_table "categories", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.text "description"
     t.bigint "company_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["company_id", "name"], name: "index_categories_on_company_id_and_name", unique: true
     t.index ["company_id"], name: "index_categories_on_company_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_25_145728) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_28_141233) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "categories", force: :cascade do |t|
+    t.string "name"
+    t.text "description"
+    t.bigint "company_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["company_id"], name: "index_categories_on_company_id"
+  end
 
   create_table "companies", force: :cascade do |t|
     t.string "company_name", null: false
@@ -52,6 +61,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_25_145728) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "categories", "companies"
   add_foreign_key "departments", "companies"
   add_foreign_key "users", "companies"
   add_foreign_key "users", "departments"

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :category do
+    sequence(:name) { |n| "カテゴリー#{n}" }
+    sequence(:description) { |n| "カテゴリー#{n}の説明文です" }
+    association :company
+
+    trait :with_items do
+      after(:create) do |category|
+        create_list(:item, 3, category: category)
+      end
+    end
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe Category, type: :model do
+  describe 'アソシエーション' do
+    it { is_expected.to belong_to(:company) }
+  end
+
+  describe 'バリデーション' do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_length_of(:name).is_at_most(50) }
+    it { is_expected.to validate_length_of(:description).is_at_most(500) }
+
+    describe '企業内でのカテゴリ名の一意性' do
+      let(:company) { create(:company) }
+      let!(:category) { create(:category, company: company, name: 'テスト') }
+
+      it '同じ企業内で同じ名前は無効であること' do
+        new_category = build(:category, company: company, name: 'テスト')
+        expect(new_category).not_to be_valid
+      end
+
+      it '異なる企業では同じ名前が有効であること' do
+        other_company = create(:company)
+        new_category = build(:category, company: other_company, name: 'テスト')
+        expect(new_category).to be_valid
+      end
+    end
+  end
+
+  describe 'ファクトリ' do
+    it '有効なファクトリを持つこと' do
+      expect(build(:category)).to be_valid
+    end
+  end
+
+  describe '基本的な操作' do
+    let(:company) { create(:company) }
+    let(:category) { create(:category, company: company) }
+
+    context '有効な属性の場合' do
+      it 'カテゴリーを作成できること' do
+        expect(category).to be_valid
+      end
+
+      it '説明がなくても有効であること' do
+        category.description = nil
+        expect(category).to be_valid
+      end
+    end
+
+    context '無効な属性の場合' do
+      it '名前がない場合は無効であること' do
+        category.name = nil
+        expect(category).not_to be_valid
+      end
+
+      it '名前が50文字を超える場合は無効であること' do
+        category.name = 'a' * 51
+        expect(category).not_to be_valid
+      end
+
+      it '説明が500文字を超える場合は無効であること' do
+        category.description = 'a' * 501
+        expect(category).not_to be_valid
+      end
+
+      it '会社に属していない場合は無効であること' do
+        category.company = nil
+        expect(category).not_to be_valid
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/categories_spec.rb
+++ b/spec/requests/api/v1/categories_spec.rb
@@ -1,0 +1,122 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Categories', type: :request do
+  let(:company) { create(:company) }
+  let(:admin) { create(:user, :admin, company: company, role: 'admin') }
+  let(:user) { create(:user, company: company) }
+  let(:category) { create(:category, company: company) }
+
+  def valid_params
+    { category: { name: '新しいカテゴリー', description: 'カテゴリーの説明' } }
+  end
+
+  def invalid_params
+    { category: { name: '', description: '' } }
+  end
+
+  describe 'GET /api/v1/companies/:company_id/categories' do
+    context '認証済みユーザーの場合' do
+      before do
+        sign_in user
+        create_list(:category, 3, company: company)
+        get api_v1_company_categories_path(company)
+      end
+
+      it '200を返すこと' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it '全てのカテゴリーを返すこと' do
+        expect(json.size).to eq(3)
+      end
+    end
+  end
+
+  describe 'GET /api/v1/companies/:company_id/categories/:id' do
+    context '認証済みユーザーの場合' do
+      before do
+        sign_in user
+        get api_v1_company_category_path(company, category)
+      end
+
+      it '200を返すこと' do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe 'POST /api/v1/companies/:company_id/categories' do
+    context '管理者の場合' do
+      before { sign_in admin }
+
+      it '有効なパラメータで作成できること' do
+        expect do
+          post api_v1_company_categories_path(company), params: valid_params
+        end.to change(Category, :count).by(1)
+        expect(response).to have_http_status(:created)
+      end
+
+      it '無効なパラメータで作成できないこと' do
+        expect do
+          post api_v1_company_categories_path(company), params: invalid_params
+        end.not_to change(Category, :count)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context '一般ユーザーの場合' do
+      before { sign_in user }
+
+      it '作成できないこと' do
+        post api_v1_company_categories_path(company), params: valid_params
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe 'PATCH /api/v1/companies/:company_id/categories/:id' do
+    context '管理者の場合' do
+      before { sign_in admin }
+
+      it '更新できること' do
+        patch api_v1_company_category_path(company, category), params: valid_params
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context '一般ユーザーの場合' do
+      before { sign_in user }
+
+      it '更新できないこと' do
+        patch api_v1_company_category_path(company, category), params: valid_params
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe 'DELETE /api/v1/companies/:company_id/categories/:id' do
+    context '管理者の場合' do
+      before { sign_in admin }
+
+      it '削除できること' do
+        delete api_v1_company_category_path(company, category)
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context '一般ユーザーの場合' do
+      before { sign_in user }
+
+      it '削除できないこと' do
+        delete api_v1_company_category_path(company, category)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  private
+
+  def json
+    @json ||= response.parsed_body
+  end
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -19,6 +19,19 @@ servers:
   - url: http://localhost:3000
     description: Development server
 
+tags:
+  - name: Companies
+    description: 企業管理API
+  - name: Departments
+    description: 部署管理API
+  - name: Categories
+    description: カテゴリ管理API
+  - name: Users
+    description: ユーザー管理API
+
+security:
+  - bearer_auth: []
+
 components:
   # 認証スキーマ
   securitySchemes:
@@ -38,64 +51,46 @@ components:
       schema:
         type: integer
         minimum: 1
-
-    DepartmentId:
+    ResourceId:
       name: id
       in: path
       required: true
-      description: 部署ID
+      description: リソースID
       schema:
         type: integer
         minimum: 1
 
   # 共通レスポンス
   responses:
-    Forbidden:
-      description: 権限エラー
+    Success:
+      description: 操作が成功しました
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
-          example:
-            error: "権限がありません"
-
-    NotFound:
-      description: リソースが見つかりません
+            $ref: "#/components/schemas/BaseResponse"
+    Created:
+      description: 作成に成功しました
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
-          example:
-            error: "リソースが見つかりません"
-
-    UnprocessableEntity:
-      description: バリデーションエラー
+            $ref: "#/components/schemas/BaseResponse"
+    NoContent:
+      description: 削除に成功しました
+    Error:
+      description: エラーが発生しました
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
-          example:
-            errors: ["バリデーションエラーが発生しました"]
+            $ref: "#/components/schemas/ErrorResponse"
 
-  # スキーマ定義
+  # 基本スキーマ
   schemas:
-    Department:
+    BaseModel:
       type: object
       properties:
         id:
           type: integer
-          description: 部署ID
-        name:
-          type: string
-          description: 部署名
-          maxLength: 50
-        description:
-          type: string
-          description: 部署の説明
-          maxLength: 500
-        company_id:
-          type: integer
-          description: 所属企業ID
+          description: ID
         created_at:
           type: string
           format: date-time
@@ -104,29 +99,16 @@ components:
           type: string
           format: date-time
           description: 更新日時
-      required:
-        - id
-        - name
-        - company_id
 
-    DepartmentInput:
+    BaseResponse:
       type: object
       properties:
-        department:
+        status:
+          type: string
+        data:
           type: object
-          properties:
-            name:
-              type: string
-              description: 部署名
-              maxLength: 50
-            description:
-              type: string
-              description: 部署の説明
-              maxLength: 500
-          required:
-            - name
 
-    Error:
+    ErrorResponse:
       type: object
       properties:
         error:
@@ -135,456 +117,120 @@ components:
           type: array
           items:
             type: string
-
-    # 企業のスキーマ
-    Company:
-      type: object
-      properties:
-        id:
+        status:
           type: integer
-          description: 企業ID
-        company_name:
-          type: string
-          description: 企業名
-        address:
-          type: string
-          description: 住所
-        phone_number:
-          type: string
-          description: 電話番号
-        subdomain:
-          type: string
-          description: サブドメイン
-        created_at:
-          type: string
-          format: date-time
-        updated_at:
-          type: string
-          format: date-time
-      required:
-        - id
-        - company_name
-        - subdomain
 
-    CompanyInput:
-      type: object
-      properties:
-        company:
-          type: object
+    # カテゴリスキーマ
+    Category:
+      allOf:
+        - $ref: "#/components/schemas/BaseModel"
+        - type: object
           properties:
-            company_name:
-              type: string
-              description: 企業名
-            address:
-              type: string
-              description: 住所
-            phone_number:
-              type: string
-              description: 電話番号
-            subdomain:
-              type: string
-              description: サブドメイン
-          required:
-            - company_name
-            - subdomain
-
-    # ユーザーのスキーマ
-    User:
-      type: object
-      properties:
-        id:
-          type: integer
-          description: ユーザーID
-        email:
-          type: string
-          format: email
-          description: メールアドレス
-        name:
-          type: string
-          description: ユーザー名
-        role:
-          type: string
-          enum: [admin, user]
-          description: ユーザー権限
-        company_id:
-          type: integer
-          description: 所属企業ID
-        department_id:
-          type: integer
-          description: 所属部署ID
-        created_at:
-          type: string
-          format: date-time
-        updated_at:
-          type: string
-          format: date-time
-      required:
-        - id
-        - email
-        - role
-        - company_id
-
-    UserInput:
-      type: object
-      properties:
-        user:
-          type: object
-          properties:
-            email:
-              type: string
-              format: email
-              description: メールアドレス
-            password:
-              type: string
-              description: パスワード
             name:
               type: string
-              description: ユーザー名
-            role:
+              description: カテゴリ名
+              maxLength: 50
+            description:
               type: string
-              enum: [admin, user]
-              description: ユーザー権限
-            department_id:
+              description: カテゴリの説明
+              maxLength: 500
+            company_id:
               type: integer
-              description: 所属部署ID
+              description: 所属企業ID
           required:
-            - email
-            - password
-            - role
+            - name
+            - company_id
+
+    CategoryInput:
+      type: object
+      properties:
+        category:
+          type: object
+          properties:
+            name:
+              type: string
+              description: カテゴリ名
+              maxLength: 50
+            description:
+              type: string
+              description: カテゴリの説明
+              maxLength: 500
+          required:
+            - name
 
 # APIパス定義
 paths:
-  /api/v1/companies/{company_id}/departments:
+  /api/v1/companies/{company_id}/categories:
     parameters:
       - $ref: "#/components/parameters/CompanyId"
 
     get:
-      tags:
-        - Departments
-      summary: 部署一覧の取得
-      description: |
-        指定した企業の部署一覧を取得します。
-        管理者のみがアクセス可能です。
-      security:
-        - bearer_auth: []
+      tags: [Categories]
+      summary: カテゴリ一覧の取得
+      description: 指定した企業のカテゴリ一覧を取得します
       responses:
         "200":
-          description: 部署一覧の取得に成功
+          description: カテゴリ一覧の取得に成功
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Department"
-              example:
-                - id: 1
-                  name: "営業部"
-                  description: "営業部門です"
-                  company_id: 1
-                  created_at: "2024-01-01T00:00:00.000Z"
-                  updated_at: "2024-01-01T00:00:00.000Z"
-        "403":
-          $ref: "#/components/responses/Forbidden"
+                  $ref: "#/components/schemas/Category"
 
     post:
-      tags:
-        - Departments
-      summary: 部署の新規作成
+      tags: [Categories]
+      summary: カテゴリの新規作成
       description: |
-        新しい部署を作成します。
+        新しいカテゴリを作成します。
         - 管理者のみが実行可能です
-        - 部署名は企業内で一意である必要がります
-        - 部署名は50文字以内です
-      security:
-        - bearer_auth: []
+        - カテゴリ名は企業内で一意である必要があります
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DepartmentInput"
-            example:
-              department:
-                name: "新規部署"
-                description: "新規部署の説明"
+              $ref: "#/components/schemas/CategoryInput"
       responses:
         "201":
-          description: 部署の作成に成功
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Department"
+          $ref: "#/components/responses/Created"
         "422":
-          $ref: "#/components/responses/UnprocessableEntity"
-        "403":
-          $ref: "#/components/responses/Forbidden"
+          $ref: "#/components/responses/Error"
 
-  /api/v1/companies/{company_id}/departments/{id}:
+  /api/v1/companies/{company_id}/categories/{id}:
     parameters:
       - $ref: "#/components/parameters/CompanyId"
-      - $ref: "#/components/parameters/DepartmentId"
+      - $ref: "#/components/parameters/ResourceId"
 
     get:
-      tags:
-        - Departments
-      summary: 部署詳細の取得
-      description: 指定した部署の詳細情報を取得します
-      security:
-        - bearer_auth: []
+      tags: [Categories]
+      summary: カテゴリ詳細の取得
       responses:
         "200":
-          description: 部署詳細の取得に成功
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Department"
+          $ref: "#/components/responses/Success"
         "404":
-          $ref: "#/components/responses/NotFound"
+          $ref: "#/components/responses/Error"
 
     patch:
-      tags:
-        - Departments
-      summary: 部署情報の更新
-      description: |
-        部署の情報を更新します。
-        - 管理者のみが実行可能です
-        - 部署名は企業内で一意である必要があります
-        - 部署名は50文字以内です
-      security:
-        - bearer_auth: []
+      tags: [Categories]
+      summary: カテゴリ情報の更新
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DepartmentInput"
+              $ref: "#/components/schemas/CategoryInput"
       responses:
         "200":
-          description: 部署の更新に成功
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Department"
+          $ref: "#/components/responses/Success"
         "422":
-          $ref: "#/components/responses/UnprocessableEntity"
+          $ref: "#/components/responses/Error"
 
     delete:
-      tags:
-        - Departments
-      summary: 部署の削除
-      description: |
-        部署を削除します。
-        - 管理者のみが実行可能です
-        - 所属するユーザーがいる場合は削除できません
-      security:
-        - bearer_auth: []
+      tags: [Categories]
+      summary: カテゴリの削除
       responses:
         "204":
-          description: 部署の削除に成功
+          $ref: "#/components/responses/NoContent"
         "422":
-          description: 削除できない部署
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-              example:
-                errors: ["所属しているユーザーが存在するため削除できません"]
-
-  # 企業関連のエンドポイント
-  /api/v1/companies:
-    get:
-      tags:
-        - Companies
-      summary: 企業一覧の取得
-      description: 全ての企業の一覧を取得します
-      security:
-        - bearer_auth: []
-      responses:
-        "200":
-          description: 企業一覧の取得に成功
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Company"
-
-    post:
-      tags:
-        - Companies
-      summary: 企業の新規作成
-      description: |
-        新しい企業を作成します。
-        - 管理者のみが実行可能です
-        - サブドメインは一意である必要があります
-      security:
-        - bearer_auth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CompanyInput"
-      responses:
-        "201":
-          description: 企業の作成に成功
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Company"
-        "422":
-          $ref: "#/components/responses/UnprocessableEntity"
-
-  /api/v1/companies/{id}:
-    parameters:
-      - name: id
-        in: path
-        required: true
-        description: 企業ID
-        schema:
-          type: integer
-          minimum: 1
-
-    get:
-      tags:
-        - Companies
-      summary: 企業詳細の取得
-      security:
-        - bearer_auth: []
-      responses:
-        "200":
-          description: 企業詳細の取得に成功
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Company"
-        "404":
-          $ref: "#/components/responses/NotFound"
-
-    patch:
-      tags:
-        - Companies
-      summary: 企業情報の更新
-      description: |
-        企業の情報を更新します。
-        - 管理者のみが実行可能です
-      security:
-        - bearer_auth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CompanyInput"
-      responses:
-        "200":
-          description: 企業情報の更新に成功
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Company"
-        "422":
-          $ref: "#/components/responses/UnprocessableEntity"
-
-  # ユーザー関連のエンドポイント
-  /api/v1/companies/{company_id}/users:
-    parameters:
-      - $ref: "#/components/parameters/CompanyId"
-
-    get:
-      tags:
-        - Users
-      summary: ユーザー一覧の取得
-      description: 指定した企業のユーザー一覧を取得します
-      security:
-        - bearer_auth: []
-      responses:
-        "200":
-          description: ユーザー一覧の取得に成功
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/User"
-
-    post:
-      tags:
-        - Users
-      summary: ユーザーの新規作成
-      description: |
-        新しいユーザーを作成します。
-        - 管理者のみが実行可能です
-        - メールアドレスは一意である必要があります
-        - 一般ユーザーは部署の所属が必須です
-      security:
-        - bearer_auth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/UserInput"
-      responses:
-        "201":
-          description: ユーザーの作成に成功
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/User"
-        "422":
-          $ref: "#/components/responses/UnprocessableEntity"
-
-  /api/v1/companies/{company_id}/users/{id}:
-    parameters:
-      - $ref: "#/components/parameters/CompanyId"
-      - name: id
-        in: path
-        required: true
-        description: ユーザーID
-        schema:
-          type: integer
-          minimum: 1
-
-    get:
-      tags:
-        - Users
-      summary: ユーザー詳細の取得
-      security:
-        - bearer_auth: []
-      responses:
-        "200":
-          description: ユーザー詳細の取得に成功
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/User"
-        "404":
-          $ref: "#/components/responses/NotFound"
-
-    patch:
-      tags:
-        - Users
-      summary: ユーザー情報の更新
-      description: |
-        ユーザーの情報を更新します。
-        - 管理者のみが実行可能です
-        - メールアドレスは一意である必要があります
-        - 一般ユーザーは部署の所属が必須です
-      security:
-        - bearer_auth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/UserInput"
-      responses:
-        "200":
-          description: ユーザー情報の更新に成功
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/User"
-        "422":
-          $ref: "#/components/responses/UnprocessableEntity"
+          $ref: "#/components/responses/Error"


### PR DESCRIPTION
# カテゴリ管理機能の実装

## 概要
消耗品を分類するためのカテゴリ管理機能を実装しました。

## 実装内容
1. カテゴリモデルの作成
   - 企業に紐づくカテゴリを管理
   - 名前と説明文のバリデーション
   - 企業内でのカテゴリ名の一意性チェック

2. カテゴリ管理API
   - 一覧取得 (GET /api/v1/companies/:company_id/categories)
   - 詳細取得 (GET /api/v1/companies/:company_id/categories/:id)
   - 作成 (POST /api/v1/companies/:company_id/categories)
   - 更新 (PATCH /api/v1/companies/:company_id/categories/:id)
   - 削除 (DELETE /api/v1/companies/:company_id/categories/:id)

3. 権限管理
   - 一覧・詳細：全ユーザーがアクセス可能
   - 作成・更新・削除：管理者のみ実行可能

## テスト内容
- モデルのバリデーションとアソシエーション
- APIエンドポイントのCRUD操作
- 権限チェック
- エラーケース

## 動作確認方法
1. マイグレーションを実行
```bash
rails db:migrate
```

2. APIドキュメントの確認
```
http://localhost:3000/api-docs
```

## 特記事項
- カテゴリ削除時のエラーハンドリングを実装
- N+1問題対策済み
- Swagger UIでAPIの動作確認が可能