### PR TITLE
feat: 発注管理機能の実装

### DIFF
--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -1,0 +1,96 @@
+module Api
+  module V1
+    class OrdersController < BaseController
+      before_action :set_order, only: %i[show update approve reject order receive]
+      before_action :authorize_admin!, only: %i[approve reject]
+
+      def index
+        orders = current_company.orders
+                                .includes(:item, :user, :approver)
+                                .order(created_at: :desc)
+        render_success(orders)
+      end
+
+      def show
+        render_success(@order)
+      end
+
+      def create
+        order = current_company.orders.build(order_params)
+        order.user = current_user
+
+        if order.save
+          render_success(order, :created)
+        else
+          Rails.logger.error "Order creation failed: #{order.errors.full_messages.join(', ')}"
+          render_error(order.errors.full_messages)
+        end
+      end
+
+      def update
+        if @order.update(order_params)
+          render_success(@order)
+        else
+          Rails.logger.error "Order update failed: #{@order.errors.full_messages.join(', ')}"
+          render_error(@order.errors.full_messages)
+        end
+      end
+
+      def approve
+        @order.approver = current_user
+        if @order.update(status: :approved)
+          render_success(@order)
+        else
+          Rails.logger.error "Order approval failed: #{@order.errors.full_messages.join(', ')}"
+          render_error(@order.errors.full_messages)
+        end
+      end
+
+      def reject
+        @order.approver = current_user
+        if @order.update(status: :rejected)
+          render_success(@order)
+        else
+          Rails.logger.error "Order rejection failed: #{@order.errors.full_messages.join(', ')}"
+          render_error(@order.errors.full_messages)
+        end
+      end
+
+      def order
+        @order.approver = current_user
+        if @order.update(status: :ordered, ordered_at: Time.current)
+          render_success(@order)
+        else
+          Rails.logger.error "Order ordering failed: #{@order.errors.full_messages.join(', ')}"
+          render_error(@order.errors.full_messages)
+        end
+      end
+
+      def receive
+        @order.approver = current_user
+        if @order.update(status: :received, received_at: Time.current)
+          render_success(@order)
+        else
+          Rails.logger.error "Order receiving failed: #{@order.errors.full_messages.join(', ')}"
+          render_error(@order.errors.full_messages)
+        end
+      end
+
+      private
+
+      def set_order
+        @order = current_company.orders.find(params[:id])
+      rescue ActiveRecord::RecordNotFound => e
+        Rails.logger.error "Order not found: #{e.message}"
+        raise
+      end
+
+      def order_params
+        params.require(:order).permit(:item_id, :quantity, :note, :status)
+      rescue ActionController::ParameterMissing => e
+        Rails.logger.error "Invalid order parameters: #{e.message}"
+        raise
+      end
+    end
+  end
+end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -4,6 +4,7 @@ class Company < ApplicationRecord
   has_many :items, dependent: :destroy
   has_many :categories, dependent: :destroy
   has_many :stocks, dependent: :destroy
+  has_many :orders, dependent: :destroy
 
   validates :name, presence: true, uniqueness: true
   validates :phone_number, presence: true

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,6 +2,7 @@ class Item < ApplicationRecord
   belongs_to :category
   belongs_to :company
   has_many :stocks, dependent: :destroy
+  has_many :orders, dependent: :destroy
 
   validates :name,
             presence: true,

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,38 @@
+class Order < ApplicationRecord
+  belongs_to :item
+  belongs_to :company
+  belongs_to :user
+  belongs_to :approver, class_name: 'User', optional: true
+
+  enum status: {
+    pending: 'pending',      # 申請中
+    approved: 'approved',    # 承認済み
+    rejected: 'rejected',    # 却下
+    ordered: 'ordered',      # 発注済み
+    received: 'received'     # 受領済み
+  }
+
+  validates :quantity, presence: true, numericality: { greater_than: 0 }
+  validates :status, presence: true
+  validates :note, length: { maximum: 500 }
+
+  validate :validate_status_transition, if: :status_changed?
+
+  private
+
+  def validate_status_transition
+    return if status_was.nil?
+
+    allowed_transitions = {
+      'pending' => %w[approved rejected],
+      'approved' => %w[ordered rejected],
+      'ordered' => %w[received],
+      'rejected' => %w[pending],
+      'received' => []
+    }
+
+    return if allowed_transitions[status_was]&.include?(status)
+
+    errors.add(:status, "cannot transition from #{status_was} to #{status}")
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -15,8 +15,9 @@ class Order < ApplicationRecord
   validates :quantity, presence: true, numericality: { greater_than: 0 }
   validates :status, presence: true
   validates :note, length: { maximum: 500 }
+  validates :approver, presence: true, if: -> { approved? || rejected? || ordered? || received? }
 
-  validate :validate_status_transition, if: :status_changed?
+  validate :validate_status_transition, if: :will_save_change_to_status?
 
   private
 
@@ -33,6 +34,6 @@ class Order < ApplicationRecord
 
     return if allowed_transitions[status_was]&.include?(status)
 
-    errors.add(:status, "cannot transition from #{status_was} to #{status}")
+    errors.add(:status, :invalid_transition, from: status_was, to: status)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,12 @@ class User < ApplicationRecord
   has_many :stocks, dependent: :restrict_with_error
   belongs_to :company
   belongs_to :department, optional: true
+  has_many :orders, dependent: :restrict_with_error
+  has_many :approved_orders,
+           class_name: 'Order',
+           foreign_key: 'approver_id',
+           inverse_of: :approver,
+           dependent: :restrict_with_error
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable

--- a/app/serializers/order_serializer.rb
+++ b/app/serializers/order_serializer.rb
@@ -1,0 +1,30 @@
+class OrderSerializer < ApplicationSerializer
+  attributes :id,
+             :quantity,
+             :status,
+             :note,
+             :ordered_at,
+             :received_at,
+             :created_at,
+             :updated_at
+
+  belongs_to :item
+  belongs_to :user
+  belongs_to :approver, optional: true
+
+  attribute :item_name do |object|
+    object.item.name
+  end
+
+  attribute :user_name do |object|
+    object.user.name
+  end
+
+  attribute :approver_name do |object|
+    object.approver&.name
+  end
+
+  attribute :status_text do |object|
+    I18n.t("enums.order.status.#{object.status}")
+  end
+end

--- a/app/serializers/order_serializer.rb
+++ b/app/serializers/order_serializer.rb
@@ -6,25 +6,45 @@ class OrderSerializer < ApplicationSerializer
              :ordered_at,
              :received_at,
              :created_at,
-             :updated_at
+             :updated_at,
+             :item_name,
+             :user_name,
+             :approver_name,
+             :status_text
 
-  belongs_to :item
-  belongs_to :user
-  belongs_to :approver, optional: true
+  belongs_to :item, serializer: ItemSerializer
+  belongs_to :user, serializer: UserSerializer
+  belongs_to :approver, serializer: UserSerializer, optional: true
 
-  attribute :item_name do |object|
-    object.item.name
+  def item_name
+    object.item&.name
   end
 
-  attribute :user_name do |object|
-    object.user.name
+  def user_name
+    object.user&.name
   end
 
-  attribute :approver_name do |object|
+  def approver_name
     object.approver&.name
   end
 
-  attribute :status_text do |object|
+  def status_text
     I18n.t("enums.order.status.#{object.status}")
+  end
+
+  def created_at
+    object.created_at&.as_json
+  end
+
+  def updated_at
+    object.updated_at&.as_json
+  end
+
+  def ordered_at
+    object.ordered_at&.as_json
+  end
+
+  def received_at
+    object.received_at&.as_json
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,6 +3,7 @@ ja:
     models:
       item: "消耗品"
       category: "カテゴリ"
+      order: 発注
     attributes:
       item:
         name: "消耗品名"
@@ -12,6 +13,16 @@ ja:
         url: "購入URL"
         purchase_notes: "購入時の注意事項"
         category_id: "カテゴリ"
+      order:
+        item: 消耗品
+        company: 企業
+        user: 申請者
+        approver: 承認者
+        quantity: 数量
+        status: ステータス
+        note: 備考
+        ordered_at: 発注日時
+        received_at: 受領日時
     errors:
       messages:
         record_invalid: "バリデーションに失敗しました: %{errors}"
@@ -37,6 +48,10 @@ ja:
         item:
           one: "消耗品"
           other: "消耗品"
+        order:
+          attributes:
+            status:
+              invalid_transition: "%{from}から%{to}への変更はできません"
 
   errors:
     messages:
@@ -48,3 +63,12 @@ ja:
     destroy:
       errors:
         users_exist: "所属しているユーザーが存在するため削除できません"
+
+  enums:
+    order:
+      status:
+        pending: 申請中
+        approved: 承認済み
+        rejected: 却下
+        ordered: 発注済み
+        received: 受領済み

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,14 @@ Rails.application.routes.draw do
       resources :items do
         resources :stocks, only: %i[index show create]
       end
+      resources :orders do
+        member do
+          patch :approve
+          patch :reject
+          patch :order
+          patch :receive
+        end
+      end
     end
   end
 end

--- a/db/migrate/20241229133925_create_orders.rb
+++ b/db/migrate/20241229133925_create_orders.rb
@@ -1,0 +1,19 @@
+class CreateOrders < ActiveRecord::Migration[7.0]
+  def change
+    create_table :orders do |t|
+      t.references :item, null: false, foreign_key: true
+      t.references :company, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.references :approver, foreign_key: { to_table: :users }
+      t.integer :quantity, null: false
+      t.string :status, null: false, default: 'pending'
+      t.text :note
+      t.datetime :ordered_at
+      t.datetime :received_at
+
+      t.timestamps
+    end
+
+    add_index :orders, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_29_130949) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_29_133925) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -61,6 +61,25 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_29_130949) do
     t.index ["name", "company_id"], name: "index_items_on_name_and_company_id", unique: true
   end
 
+  create_table "orders", force: :cascade do |t|
+    t.bigint "item_id", null: false
+    t.bigint "company_id", null: false
+    t.bigint "user_id", null: false
+    t.bigint "approver_id"
+    t.integer "quantity", null: false
+    t.string "status", default: "pending", null: false
+    t.text "note"
+    t.datetime "ordered_at"
+    t.datetime "received_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["approver_id"], name: "index_orders_on_approver_id"
+    t.index ["company_id"], name: "index_orders_on_company_id"
+    t.index ["item_id"], name: "index_orders_on_item_id"
+    t.index ["status"], name: "index_orders_on_status"
+    t.index ["user_id"], name: "index_orders_on_user_id"
+  end
+
   create_table "stocks", force: :cascade do |t|
     t.bigint "item_id", null: false
     t.bigint "company_id", null: false
@@ -100,6 +119,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_29_130949) do
   add_foreign_key "departments", "companies"
   add_foreign_key "items", "categories"
   add_foreign_key "items", "companies"
+  add_foreign_key "orders", "companies"
+  add_foreign_key "orders", "items"
+  add_foreign_key "orders", "users"
+  add_foreign_key "orders", "users", column: "approver_id"
   add_foreign_key "stocks", "companies"
   add_foreign_key "stocks", "items"
   add_foreign_key "stocks", "users"

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,42 @@
+FactoryBot.define do
+  factory :order do
+    association :item
+    association :company
+    association :user
+    association :approver, factory: :user, role: :admin
+    quantity { rand(1..100) }
+    status { 'pending' }
+    note { 'テスト発注' }
+
+    trait :approved do
+      after(:create) do |order|
+        order.approver ||= create(:user, :admin, company: order.company)
+        order.update!(status: 'approved')
+      end
+    end
+
+    trait :rejected do
+      after(:create) do |order|
+        order.approver ||= create(:user, :admin, company: order.company)
+        order.update!(status: 'rejected')
+      end
+    end
+
+    trait :ordered do
+      after(:create) do |order|
+        order.approver ||= create(:user, :admin, company: order.company)
+        order.update!(status: 'approved')
+        order.update!(status: 'ordered', ordered_at: Time.current)
+      end
+    end
+
+    trait :received do
+      after(:create) do |order|
+        order.approver ||= create(:user, :admin, company: order.company)
+        order.update!(status: 'approved')
+        order.update!(status: 'ordered', ordered_at: 1.day.ago)
+        order.update!(status: 'received', received_at: Time.current)
+      end
+    end
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  describe 'アソシエーション' do
+    it { is_expected.to belong_to(:item) }
+    it { is_expected.to belong_to(:company) }
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:approver).optional }
+  end
+
+  describe 'バリデーション' do
+    subject { build(:order) }
+
+    it { is_expected.to validate_presence_of(:quantity) }
+    it { is_expected.to validate_numericality_of(:quantity).is_greater_than(0) }
+    it { is_expected.to validate_presence_of(:status) }
+    it { is_expected.to validate_length_of(:note).is_at_most(500) }
+  end
+
+  describe 'ステータス遷移' do
+    let(:order) { create(:order) }
+
+    context 'pending（申請中）の場合' do
+      it 'approved（承認済み）に変更できること' do
+        expect(order.update(status: :approved)).to be true
+      end
+
+      it 'rejected（却下）に変更できること' do
+        expect(order.update(status: :rejected)).to be true
+      end
+
+      it 'ordered（発注済み）に直接変更できないこと' do
+        expect(order.update(status: :ordered)).to be false
+      end
+    end
+
+    context 'approved（承認済み）の場合' do
+      let(:order) { create(:order, :approved) }
+
+      it 'ordered（発注済み）に変更できること' do
+        expect(order.update(status: :ordered)).to be true
+      end
+
+      it 'rejected（却下）に変更できること' do
+        expect(order.update(status: :rejected)).to be true
+      end
+
+      it 'received（受領済み）に直接変更できないこと' do
+        expect(order.update(status: :received)).to be false
+      end
+    end
+
+    context 'ordered（発注済み）の場合' do
+      let(:order) { create(:order, :ordered) }
+
+      it 'received（受領済み）に変更できること' do
+        expect(order.update(status: :received)).to be true
+      end
+
+      it '他のステータスに変更できないこと' do
+        expect(order.update(status: :pending)).to be false
+        expect(order.update(status: :approved)).to be false
+        expect(order.update(status: :rejected)).to be false
+      end
+    end
+
+    context 'rejected（却下）の場合' do
+      let(:order) { create(:order, :rejected) }
+
+      it 'pending（申請中）に変更できること' do
+        expect(order.update(status: :pending)).to be true
+      end
+
+      it '他のステータスに変更できないこと' do
+        expect(order.update(status: :approved)).to be false
+        expect(order.update(status: :ordered)).to be false
+        expect(order.update(status: :received)).to be false
+      end
+    end
+
+    context 'received（受領済み）の場合' do
+      let(:order) { create(:order, :received) }
+
+      it '申請中や承認済みに変更できないこと' do
+        expect(order.update(status: :pending)).to be false
+        expect(order.update(status: :approved)).to be false
+      end
+
+      it '却下や発注済みに変更できないこと' do
+        expect(order.update(status: :rejected)).to be false
+        expect(order.update(status: :ordered)).to be false
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/orders_spec.rb
+++ b/spec/requests/api/v1/orders_spec.rb
@@ -1,0 +1,171 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Orders', type: :request do
+  let(:company) { create(:company) }
+  let(:admin) { create(:user, :admin, company: company) }
+  let(:user) { create(:user, company: company) }
+  let(:item) { create(:item, company: company) }
+  let(:order) { create(:order, company: company, user: user, item: item) }
+
+  before do
+    host! 'localhost'
+  end
+
+  describe 'GET /api/v1/orders' do
+    before do
+      create_list(:order, 3, company: company, user: user, item: item)
+    end
+
+    context '認証済みユーザーの場合' do
+      before do
+        sign_in user
+      end
+
+      it '発注一覧を取得できること' do
+        get api_v1_orders_path
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body.size).to eq 3
+      end
+    end
+  end
+
+  describe 'GET /api/v1/orders/:id' do
+    context '認証済みユーザーの場合' do
+      before do
+        sign_in user
+      end
+
+      it '指定した発注の情報を取得できること' do
+        get api_v1_order_path(order)
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['id']).to eq order.id
+      end
+    end
+  end
+
+  describe 'POST /api/v1/orders' do
+    def valid_params
+      {
+        order: {
+          item_id: item.id,
+          quantity: 10,
+          note: 'テスト発注'
+        }
+      }
+    end
+
+    context '認証済みユーザーの場合' do
+      before do
+        sign_in user
+      end
+
+      it '発注を作成できること' do
+        expect do
+          post api_v1_orders_path, params: valid_params
+        end.to change(Order, :count).by(1)
+        expect(response).to have_http_status(:created)
+      end
+
+      context '無効なパラメータの場合' do
+        it '発注を作成できないこと' do
+          expect do
+            post api_v1_orders_path, params: { order: { item_id: item.id } }
+          end.not_to change(Order, :count)
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+  end
+
+  describe 'PATCH /api/v1/orders/:id/approve' do
+    context '認証済み管理者の場合' do
+      before do
+        sign_in admin
+      end
+
+      it '発注を承認できること' do
+        patch approve_api_v1_order_path(order)
+        expect(response).to have_http_status(:ok)
+        expect(order.reload.status).to eq 'approved'
+        expect(order.approver).to eq admin
+      end
+    end
+
+    context '認証済み一般ユーザーの場合' do
+      before do
+        sign_in user
+      end
+
+      it '発注を承認できないこと' do
+        patch approve_api_v1_order_path(order)
+        expect(response).to have_http_status(:forbidden)
+        expect(order.reload.status).to eq 'pending'
+      end
+    end
+  end
+
+  describe 'PATCH /api/v1/orders/:id/reject' do
+    context '認証済み管理者の場合' do
+      before do
+        sign_in admin
+      end
+
+      it '発注を却下できること' do
+        patch reject_api_v1_order_path(order)
+        expect(response).to have_http_status(:ok)
+        expect(order.reload.status).to eq 'rejected'
+        expect(order.approver).to eq admin
+      end
+    end
+
+    context '認証済み一般ユーザーの場合' do
+      before do
+        sign_in user
+      end
+
+      it '発注を却下できないこと' do
+        patch reject_api_v1_order_path(order)
+        expect(response).to have_http_status(:forbidden)
+        expect(order.reload.status).to eq 'pending'
+      end
+    end
+  end
+
+  describe 'PATCH /api/v1/orders/:id/order' do
+    def approved_order
+      @approved_order ||= create(:order, :approved, company: company, user: user, item: item)
+    end
+
+    context '認証済み管理者の場合' do
+      before do
+        sign_in admin
+      end
+
+      it '承認済みの発注を発注済みにできること' do
+        patch order_api_v1_order_path(approved_order)
+        expect(response).to have_http_status(:ok)
+        expect(approved_order.reload.status).to eq 'ordered'
+        expect(approved_order.ordered_at).to be_present
+      end
+    end
+  end
+
+  describe 'PATCH /api/v1/orders/:id/receive' do
+    def ordered_order
+      @ordered_order ||= create(:order, :ordered, company: company, user: user, item: item)
+    end
+
+    context '認証済み管理者の場合' do
+      before do
+        sign_in admin
+      end
+
+      it '発注済みの発注を受領済みにできること' do
+        patch receive_api_v1_order_path(ordered_order)
+        expect(response).to have_http_status(:ok)
+        expect(ordered_order.reload.status).to eq 'received'
+        expect(ordered_order.received_at).to be_present
+      end
+    end
+  end
+end

--- a/spec/serializers/order_serializer_spec.rb
+++ b/spec/serializers/order_serializer_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.describe OrderSerializer, type: :serializer do
+  let(:company) { create(:company) }
+  let(:user) { create(:user, company: company) }
+  let(:admin) { create(:user, :admin, company: company) }
+  let(:item) { create(:item, company: company) }
+  let(:order) { create(:order, company: company, user: user, item: item, approver: admin) }
+
+  def serializer
+    @serializer ||= described_class.new(order)
+  end
+
+  def serialization
+    @serialization ||= serializer.as_json
+  end
+
+  describe '基本属性' do
+    it '正しい属性が含まれていること' do
+      expect(serialization).to include(
+        id: order.id,
+        quantity: order.quantity,
+        status: order.status,
+        note: order.note,
+        ordered_at: order.ordered_at&.as_json,
+        received_at: order.received_at&.as_json,
+        created_at: order.created_at&.as_json,
+        updated_at: order.updated_at&.as_json
+      )
+    end
+  end
+
+  describe '関連' do
+    it '関連するモデルの情報が含まれていること' do
+      expect(serialization[:item]).to be_present
+      expect(serialization[:user]).to be_present
+      expect(serialization[:approver]).to be_present
+    end
+
+    context '承認者がいない場合' do
+      let(:order) { create(:order, company: company, user: user, item: item, approver: nil) }
+
+      it 'approverがnullであること' do
+        expect(serialization[:approver]).to be_nil
+      end
+    end
+  end
+
+  describe '派生属性' do
+    it '消耗品名が含まれていること' do
+      expect(serialization[:item_name]).to eq order.item.name
+    end
+
+    it '申請者名が含まれていること' do
+      expect(serialization[:user_name]).to eq order.user.name
+    end
+
+    it '承認者名が含まれていること' do
+      expect(serialization[:approver_name]).to eq order.approver.name
+    end
+
+    it 'ステータスの日本語表示が含まれていること' do
+      expect(serialization[:status_text]).to eq I18n.t("enums.order.status.#{order.status}")
+    end
+
+    context '承認者がいない場合' do
+      let(:order) { create(:order, company: company, user: user, item: item, approver: nil) }
+
+      it '承認者名がnullであること' do
+        expect(serialization[:approver_name]).to be_nil
+      end
+    end
+  end
+
+  describe 'ステータスごとの表示' do
+    def create_order_with_status(trait)
+      order = create(:order, trait, company: company, user: user, item: item)
+      [order, described_class.new(order).as_json]
+    end
+
+    it '申請中と承認済みのステータスが正しく日本語化されていること' do
+      %i[pending approved].each do |status|
+        _, serialization = create_order_with_status(status)
+        expect(serialization[:status_text]).to eq I18n.t("enums.order.status.#{status}")
+      end
+    end
+
+    it '却下と発注済みのステータスが正しく日本語化されていること' do
+      %i[rejected ordered].each do |status|
+        _, serialization = create_order_with_status(status)
+        expect(serialization[:status_text]).to eq I18n.t("enums.order.status.#{status}")
+      end
+    end
+  end
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -32,6 +32,8 @@ tags:
     description: 消耗品管理API
   - name: Stocks
     description: 在庫管理API
+  - name: Orders
+    description: 発注管理API
 
 security:
   - bearer_auth: []
@@ -94,20 +96,6 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
-    StockList:
-      description: 在庫履歴一覧の取得に成功
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              $ref: "#/components/schemas/Stock"
-    StockDetail:
-      description: 在庫履歴詳細の取得に成功
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/Stock"
 
   # 基本スキーマ
   schemas:
@@ -329,6 +317,94 @@ components:
             - quantity
             - operation_type
 
+    # 発注スキーマ
+    Order:
+      allOf:
+        - $ref: "#/components/schemas/BaseModel"
+        - type: object
+          properties:
+            item_id:
+              type: integer
+              description: 消耗品ID
+            user_id:
+              type: integer
+              description: 申請者ID
+            approver_id:
+              type: integer
+              description: 承認者ID
+              nullable: true
+            company_id:
+              type: integer
+              description: 所属企業ID
+            quantity:
+              type: integer
+              description: 数量
+              minimum: 1
+            status:
+              type: string
+              enum: [pending, approved, rejected, ordered, received]
+              description: |
+                ステータス
+                - pending: 申請中
+                - approved: 承認済
+                - rejected: 却下
+                - ordered: 発注済
+                - received: 受領済
+            note:
+              type: string
+              description: 備考
+              maxLength: 1000
+            ordered_at:
+              type: string
+              format: date-time
+              description: 発注日時
+              nullable: true
+            received_at:
+              type: string
+              format: date-time
+              description: 受領日時
+              nullable: true
+            item_name:
+              type: string
+              description: 消耗品名
+            user_name:
+              type: string
+              description: 申請者名
+            approver_name:
+              type: string
+              description: 承認者名
+              nullable: true
+            status_text:
+              type: string
+              description: ステータスの日本語表示
+          required:
+            - item_id
+            - user_id
+            - company_id
+            - quantity
+            - status
+
+    OrderInput:
+      type: object
+      properties:
+        order:
+          type: object
+          properties:
+            item_id:
+              type: integer
+              description: 消耗品ID
+            quantity:
+              type: integer
+              description: 数量
+              minimum: 1
+            note:
+              type: string
+              description: 備考
+              maxLength: 1000
+          required:
+            - item_id
+            - quantity
+
 # APIパス定義
 paths:
   /api/v1/companies/{company_id}/categories:
@@ -544,4 +620,141 @@ paths:
         "401":
           $ref: "#/components/responses/Error"
         "404":
+          $ref: "#/components/responses/Error"
+
+  /api/v1/orders:
+    get:
+      tags: [Orders]
+      summary: 発注一覧の取得
+      description: 所属企業の発注一覧を取得します
+      responses:
+        "200":
+          description: 発注一覧の取得に成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Order"
+        "401":
+          $ref: "#/components/responses/Error"
+
+    post:
+      tags: [Orders]
+      summary: 発注の新規作成
+      description: 新しい発注を作成します
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OrderInput"
+      responses:
+        "201":
+          $ref: "#/components/responses/Created"
+        "422":
+          $ref: "#/components/responses/Error"
+
+  /api/v1/orders/{id}:
+    parameters:
+      - $ref: "#/components/parameters/ResourceId"
+
+    get:
+      tags: [Orders]
+      summary: 発注詳細の取得
+      responses:
+        "200":
+          description: 発注詳細の取得に成功
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+        "404":
+          $ref: "#/components/responses/Error"
+
+    patch:
+      tags: [Orders]
+      summary: 発注情報の更新
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OrderInput"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+        "422":
+          $ref: "#/components/responses/Error"
+
+  /api/v1/orders/{id}/approve:
+    parameters:
+      - $ref: "#/components/parameters/ResourceId"
+
+    patch:
+      tags: [Orders]
+      summary: 発注の承認
+      description: |
+        発注を承認します
+        - 管理者のみが実行可能です
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+        "403":
+          $ref: "#/components/responses/Error"
+        "422":
+          $ref: "#/components/responses/Error"
+
+  /api/v1/orders/{id}/reject:
+    parameters:
+      - $ref: "#/components/parameters/ResourceId"
+
+    patch:
+      tags: [Orders]
+      summary: 発注の却下
+      description: |
+        発注を却下します
+        - 管理者のみが実行可能です
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+        "403":
+          $ref: "#/components/responses/Error"
+        "422":
+          $ref: "#/components/responses/Error"
+
+  /api/v1/orders/{id}/order:
+    parameters:
+      - $ref: "#/components/parameters/ResourceId"
+
+    patch:
+      tags: [Orders]
+      summary: 発注処理の実行
+      description: |
+        承認済みの発注を発注済みにします
+        - 管理者のみが実行可能です
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+        "403":
+          $ref: "#/components/responses/Error"
+        "422":
+          $ref: "#/components/responses/Error"
+
+  /api/v1/orders/{id}/receive:
+    parameters:
+      - $ref: "#/components/parameters/ResourceId"
+
+    patch:
+      tags: [Orders]
+      summary: 発注品の受領
+      description: |
+        発注済みの商品を受領済みにします
+        - 管理者のみが実行可能です
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+        "403":
+          $ref: "#/components/responses/Error"
+        "422":
           $ref: "#/components/responses/Error"


### PR DESCRIPTION
## 概要
消耗品の発注管理機能を実装しました。ユーザーは発注申請を作成し、管理者が承認・却下できる機能です。

## 実装内容
### モデル
- `Order` モデルの実装
  - 基本属性（item_id, user_id, approver_id, quantity, status, note）
  - バリデーション（必須チェック、数量チェック）
  - ステータス管理（pending, approved, rejected, ordered, received）
  - ステータス遷移の制御

### API
- 発注管理API（Orders）の実装
  - GET /api/v1/orders: 発注一覧の取得
  - POST /api/v1/orders: 発注の新規作成
  - GET /api/v1/orders/:id: 発注詳細の取得
  - PATCH /api/v1/orders/:id: 発注情報の更新
  - PATCH /api/v1/orders/:id/approve: 発注の承認
  - PATCH /api/v1/orders/:id/reject: 発注の却下
  - PATCH /api/v1/orders/:id/order: 発注処理の実行
  - PATCH /api/v1/orders/:id/receive: 発注品の受領

### シリアライザー
- `OrderSerializer` の実装
  - 基本属性
  - 関連（item, user, approver）
  - 派生属性（item_name, user_name, approver_name, status_text）

### テスト
- モデルスペック
- リクエストスペック
- シリアライザースペック

### ドキュメント
- Swaggerドキュメントの追加
  - 各APIエンドポイントの定義
  - リクエスト/レスポンスの定義
  - 認証要件の記述

## 補足
- 在庫管理機能との連携は別PRで対応予定
- メール通知機能は別PRで対応予定