### PR TITLE
feat: 発注受領時の在庫管理機能を実装

### DIFF
--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class OrdersController < BaseController
       before_action :set_order, only: %i[show update approve reject order receive]
-      before_action :authorize_admin!, only: %i[approve reject]
+      before_action :authorize_admin!, only: %i[approve reject order receive]
 
       def index
         orders = current_company.orders
@@ -67,10 +67,7 @@ module Api
       end
 
       def receive
-        authorize @order
-
         @order.with_lock do
-          @order.receive!
           @order.receive_stock!
           render_success(@order)
         rescue ActiveRecord::RecordInvalid => e

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -15,23 +15,23 @@ class Order < ApplicationRecord
   validates :quantity, presence: true, numericality: { greater_than: 0 }
   validates :status, presence: true
   validates :note, length: { maximum: 500 }
-  validates :approver, presence: true, if: -> { approved? || rejected? || ordered? || received? }
+  validate :validate_status_transition, if: :status_changed?
 
-  validate :validate_status_transition, if: :will_save_change_to_status?
+  def receive!
+    return false if received?
+
+    transaction do
+      update!(status: :received, received_at: Time.current)
+      create_stock_history!
+      true
+    end
+  end
 
   def receive_stock!
-    ActiveRecord::Base.transaction do
-      item.update!(quantity: item.quantity + quantity)
+    return if receive!
 
-      item.stocks.create!(
-        quantity: quantity,
-        operation_type: :receive,
-        note: "発注品受領 (発注ID: #{id})",
-        user: approver
-      )
-
-      update!(received_at: Time.current)
-    end
+    errors.add(:base, :unexpected_error)
+    raise ActiveRecord::RecordInvalid, self
   end
 
   private
@@ -49,6 +49,16 @@ class Order < ApplicationRecord
 
     return if allowed_transitions[status_was]&.include?(status)
 
-    errors.add(:status, :invalid_transition, from: status_was, to: status)
+    errors.add(:status, :invalid)
+  end
+
+  def create_stock_history!
+    item.stocks.create!(
+      quantity: quantity,
+      operation_type: :addition,
+      note: "発注品受領 (発注ID: #{id})",
+      user: approver,
+      company: company
+    )
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -19,6 +19,21 @@ class Order < ApplicationRecord
 
   validate :validate_status_transition, if: :will_save_change_to_status?
 
+  def receive_stock!
+    ActiveRecord::Base.transaction do
+      item.update!(quantity: item.quantity + quantity)
+
+      item.stocks.create!(
+        quantity: quantity,
+        operation_type: :receive,
+        note: "発注品受領 (発注ID: #{id})",
+        user: approver
+      )
+
+      update!(received_at: Time.current)
+    end
+  end
+
   private
 
   def validate_status_transition

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -3,39 +3,42 @@ FactoryBot.define do
     association :item
     association :company
     association :user
-    association :approver, factory: :user, role: :admin
-    quantity { rand(1..100) }
-    status { 'pending' }
+    quantity { 1 }
     note { 'テスト発注' }
+    status { :pending }
+
+    trait :pending do
+      status { :pending }
+    end
 
     trait :approved do
       after(:create) do |order|
-        order.approver ||= create(:user, :admin, company: order.company)
-        order.update!(status: 'approved')
-      end
-    end
-
-    trait :rejected do
-      after(:create) do |order|
-        order.approver ||= create(:user, :admin, company: order.company)
-        order.update!(status: 'rejected')
+        order.approver = create(:user, :admin, company: order.company)
+        order.update!(status: :approved)
       end
     end
 
     trait :ordered do
       after(:create) do |order|
-        order.approver ||= create(:user, :admin, company: order.company)
-        order.update!(status: 'approved')
-        order.update!(status: 'ordered', ordered_at: Time.current)
+        order.approver = create(:user, :admin, company: order.company)
+        order.update!(status: :approved)
+        order.update!(status: :ordered, ordered_at: Time.current)
       end
     end
 
     trait :received do
       after(:create) do |order|
-        order.approver ||= create(:user, :admin, company: order.company)
-        order.update!(status: 'approved')
-        order.update!(status: 'ordered', ordered_at: 1.day.ago)
-        order.update!(status: 'received', received_at: Time.current)
+        order.approver = create(:user, :admin, company: order.company)
+        order.update!(status: :approved)
+        order.update!(status: :ordered, ordered_at: Time.current)
+        order.update!(status: :received, received_at: Time.current)
+      end
+    end
+
+    trait :rejected do
+      after(:create) do |order|
+        order.approver = create(:user, :admin, company: order.company)
+        order.update!(status: :rejected)
       end
     end
   end

--- a/spec/support/request_spec_helper.rb
+++ b/spec/support/request_spec_helper.rb
@@ -1,0 +1,9 @@
+module RequestSpecHelper
+  def json
+    @json ||= JSON.parse(response.body)
+  end
+end
+
+RSpec.configure do |config|
+  config.include RequestSpecHelper, type: :request
+end


### PR DESCRIPTION
# 発注機能のリファクタリングと受領機能の実装

## 変更内容

### 発注モデルの改善
- ステータス遷移のバリデーション追加
  - 各ステータスで許可された遷移のみ可能に
  - 不正な遷移を防止
- 受領処理のメソッド追加
  - `receive!`: 受領処理の実行
  - `receive_stock!`: 在庫履歴作成を含む受領処理
- 在庫履歴作成処理を別メソッドに分離

### 発注コントローラーの改善
- 管理者権限チェックを`before_action`に統一
- エラーハンドリングの統一化
- レスポンス形式の統一

### テストの追加と改善
- ステータス遷移の詳細なテストケース追加
- 受領機能の正常系・異常系テスト追加
- 同時実行時の楽観的ロックのテスト追加

### その他の改善
- 部門コントローラーのレスポンス形式統一
- リクエストスペックヘルパーの追加

## 補足
- トランザクション処理を追加し、データの整合性を担保
- テストカバレッジを向上させ、品質を確保