### PR TITLE
feat: 消耗品に在庫数カラムを追加

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -4,8 +4,13 @@ module Api
       include Devise::Controllers::Helpers
 
       before_action :authenticate_user!
+      before_action :set_current_user
 
       private
+
+      def set_current_user
+        Current.user = current_user
+      end
 
       def render_success(data, status = :ok)
         render json: { data: data }, status: status

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -8,7 +8,7 @@ module Api
       private
 
       def render_success(data, status = :ok)
-        render json: data, status: status
+        render json: { data: data }, status: status
       end
 
       def render_error(message, status = :unprocessable_entity)
@@ -23,6 +23,10 @@ module Api
 
       def current_company
         current_user&.company
+      end
+
+      def log_error(resource:, action:, message:)
+        Rails.logger.error "#{resource.to_s.capitalize} #{action} failed: #{Array(message).join(', ')}"
       end
     end
   end

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -1,36 +1,36 @@
 module Api
   module V1
     class ItemsController < BaseController
-      before_action :authorize_admin!, except: %i[index show]
-      before_action :set_item, only: %i[show update destroy]
+      before_action :authorize_admin!, except: %i[index show update_stock]
+      before_action :set_item, only: %i[show update destroy update_stock]
 
       def index
         @items = filtered_items
-        render json: { data: @items.sorted.as_json(include: :category) }
+        render_success(@items.sorted.as_json(include: :category))
       rescue StandardError => e
-        log_error('index', e.message)
+        log_error(resource: :item, action: :index, message: e.message)
         render_error([I18n.t('errors.messages.unexpected_error')], :internal_server_error)
       end
 
       def show
-        render json: { data: @item.as_json(include: :category) }
+        render_success(serialize_item(@item))
       end
 
       def create
         @item = current_company.items.build(item_params)
         if @item.save
-          render json: { data: @item.as_json(include: :category) }, status: :created
+          render_success(serialize_item(@item), :created)
         else
-          log_error('creation', @item.errors.full_messages)
+          log_error(resource: :item, action: :creation, message: @item.errors.full_messages)
           render_error(@item.errors.full_messages, :unprocessable_entity)
         end
       end
 
       def update
         if @item.update(item_params)
-          render json: { data: @item.as_json(include: :category) }
+          render_success(serialize_item(@item))
         else
-          log_error('update', @item.errors.full_messages)
+          log_error(resource: :item, action: :update, message: @item.errors.full_messages)
           render_error(@item.errors.full_messages, :unprocessable_entity)
         end
       end
@@ -39,9 +39,16 @@ module Api
         if @item.destroy
           head :no_content
         else
-          log_error('deletion', @item.errors.full_messages)
+          log_error(resource: :item, action: :deletion, message: @item.errors.full_messages)
           render_error(@item.errors.full_messages, :unprocessable_entity)
         end
+      end
+
+      def update_stock
+        @item.update_stock_quantity!(stock_params.to_h.symbolize_keys)
+        render_success(serialize_item(@item))
+      rescue ArgumentError, ActiveRecord::RecordInvalid => e
+        handle_stock_update_error(e)
       end
 
       private
@@ -70,6 +77,21 @@ module Api
 
       def log_error(action, error_messages)
         Rails.logger.error "Item #{action} failed: #{Array(error_messages).join(', ')}"
+      end
+
+      def stock_params
+        params.require(:stock).permit(:quantity, :operation_type)
+      end
+
+      def handle_stock_update_error(error)
+        case error
+        when ArgumentError
+          log_error(resource: :item, action: :stock_update, message: error.message)
+          render_error([error.message], :unprocessable_entity)
+        when ActiveRecord::RecordInvalid
+          log_error(resource: :item, action: :stock_update, message: error.record.errors.full_messages)
+          render_error(error.record.errors.full_messages, :unprocessable_entity)
+        end
       end
     end
   end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,3 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :user
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -24,4 +24,17 @@ class Item < ApplicationRecord
   def stock_history
     stocks.order(operated_at: :desc)
   end
+
+  def update_stock_quantity!(quantity:, operation_type:)
+    transaction do
+      new_quantity = operation_type == 'addition' ? stock_quantity + quantity : stock_quantity - quantity
+
+      if new_quantity.negative?
+        errors.add(:stock_quantity, :insufficient_stock)
+        raise ActiveRecord::RecordInvalid, self
+      end
+
+      update!(stock_quantity: new_quantity)
+    end
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,7 +2,7 @@ class Item < ApplicationRecord
   belongs_to :category
   belongs_to :company
   has_many :stocks, dependent: :destroy
-  has_many :orders, dependent: :destroy
+  has_many :orders, dependent: :restrict_with_error
 
   validates :name,
             presence: true,
@@ -14,12 +14,14 @@ class Item < ApplicationRecord
   validates :unit, length: { maximum: 20 }
   validates :url, format: { with: URI::DEFAULT_PARSER.make_regexp }, allow_blank: true
   validates :purchase_notes, length: { maximum: 1000 }
+  validates :stock_quantity,
+            presence: true,
+            numericality: {
+              only_integer: true,
+              greater_than_or_equal_to: 0
+            }
 
   scope :sorted, -> { order(:name) }
-
-  def current_stock
-    stocks.sum(:quantity)
-  end
 
   def stock_history
     stocks.order(operated_at: :desc)
@@ -27,12 +29,24 @@ class Item < ApplicationRecord
 
   def update_stock_quantity!(quantity:, operation_type:)
     transaction do
-      new_quantity = operation_type == 'addition' ? stock_quantity + quantity : stock_quantity - quantity
+      new_quantity = case operation_type.to_s
+                     when 'addition' then stock_quantity + quantity
+                     when 'subtraction' then stock_quantity - quantity
+                     else
+                       raise ArgumentError, "Invalid operation_type: #{operation_type}"
+                     end
 
       if new_quantity.negative?
         errors.add(:stock_quantity, :insufficient_stock)
         raise ActiveRecord::RecordInvalid, self
       end
+
+      stocks.create!(
+        quantity: operation_type.to_s == 'addition' ? quantity : -quantity,
+        operated_at: Time.current,
+        company: company,
+        user: Current.user
+      )
 
       update!(stock_quantity: new_quantity)
     end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -3,7 +3,7 @@ class ItemSerializer < ApplicationSerializer
              :name,
              :description,
              :minimum_quantity,
-             :current_stock,
+             :stock_quantity,
              :unit,
              :url,
              :purchase_notes,

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -52,6 +52,10 @@ ja:
           attributes:
             status:
               invalid_transition: "%{from}から%{to}への変更はできません"
+        item:
+          attributes:
+            stock_quantity:
+              insufficient_stock: "在庫が不足しています"
 
   errors:
     messages:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,14 +10,18 @@ Rails.application.routes.draw do
       resources :companies, only: %i[index show create update] do
         resources :departments, only: %i[index show create update destroy]
         resources :users, only: %i[index show create update]
-      end
-      resources :companies do
         resources :categories, only: %i[index show create update destroy]
-        resources :items, only: %i[index show create update destroy]
+        resources :items do
+          member do
+            patch :update_stock
+          end
+        end
       end
+
       resources :items do
         resources :stocks, only: %i[index show create]
       end
+
       resources :orders do
         member do
           patch :approve

--- a/db/migrate/20241230145320_add_stock_quantity_to_items.rb
+++ b/db/migrate/20241230145320_add_stock_quantity_to_items.rb
@@ -1,0 +1,5 @@
+class AddStockQuantityToItems < ActiveRecord::Migration[7.0]
+  def change
+    add_column :items, :stock_quantity, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_29_133925) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_30_145320) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -56,6 +56,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_29_133925) do
     t.bigint "company_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "stock_quantity", default: 0, null: false
     t.index ["category_id"], name: "index_items_on_category_id"
     t.index ["company_id"], name: "index_items_on_company_id"
     t.index ["name", "company_id"], name: "index_items_on_name_and_company_id", unique: true

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     unit { '個' }
     sequence(:url) { |n| "https://example.com/items/#{n}" }
     sequence(:purchase_notes) { |n| "購入時の注意事項#{n}" }
+    stock_quantity { 0 }
     association :category
     association :company
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require_relative '../config/environment'
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
+require 'current'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/requests/api/v1/companies_spec.rb
+++ b/spec/requests/api/v1/companies_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Api::V1::Companies', type: :request do
       it '企業一覧を取得できること' do
         get api_v1_companies_path
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body.size).to eq 5
+        expect(response.parsed_body['data'].size).to eq 5
       end
     end
   end
@@ -34,7 +34,7 @@ RSpec.describe 'Api::V1::Companies', type: :request do
       it '指定した企業の情報を取得できること' do
         get api_v1_company_path(company)
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body['name']).to eq company.name
+        expect(response.parsed_body['data']['name']).to eq company.name
       end
     end
   end
@@ -62,7 +62,7 @@ RSpec.describe 'Api::V1::Companies', type: :request do
           end.to change(Company, :count).by(1)
 
           expect(response).to have_http_status(:created)
-          expect(response.parsed_body['name']).to eq '株式会社テスト'
+          expect(response.parsed_body['data']['name']).to eq '株式会社テスト'
         end
       end
 

--- a/spec/requests/api/v1/orders_spec.rb
+++ b/spec/requests/api/v1/orders_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Api::V1::Orders', type: :request do
       it '発注一覧を取得できること' do
         get api_v1_orders_path
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body.size).to eq 3
+        expect(response.parsed_body['data'].size).to eq 3
       end
     end
   end
@@ -38,7 +38,7 @@ RSpec.describe 'Api::V1::Orders', type: :request do
       it '指定した発注の情報を取得できること' do
         get api_v1_order_path(order)
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body['id']).to eq order.id
+        expect(response.parsed_body['data']['id']).to eq order.id
       end
     end
   end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Api::V1::Users', type: :request do
     it 'ユーザー一覧を取得できること' do
       get api_v1_company_users_path(company_id: company.id)
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body.size).to eq 4
+      expect(response.parsed_body['data'].size).to eq 4
     end
   end
 
@@ -40,7 +40,7 @@ RSpec.describe 'Api::V1::Users', type: :request do
       it '指定したユーザーの情報を取得できること' do
         get api_v1_company_user_path(company, user)
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body['email']).to eq user.email
+        expect(response.parsed_body['data']['email']).to eq user.email
       end
     end
   end
@@ -58,7 +58,7 @@ RSpec.describe 'Api::V1::Users', type: :request do
           end.to change(User, :count).by(1)
 
           expect(response).to have_http_status(:created)
-          expect(response.parsed_body['email']).to eq 'test@example.com'
+          expect(response.parsed_body['data']['email']).to eq 'test@example.com'
         end
       end
 

--- a/spec/serializers/item_serializer_spec.rb
+++ b/spec/serializers/item_serializer_spec.rb
@@ -1,13 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe ItemSerializer, type: :serializer do
-  let(:item) { create(:item) }
+  let(:company) { create(:company) }
+  let(:category) { create(:category, company: company) }
+  let(:item) { create(:item, company: company, category: category) }
   let(:serializer) { described_class.new(item) }
   let(:serialization) { JSON.parse(serializer.to_json) }
 
   it '基本的な属性がシリアライズされること' do
     expect(serialization.keys).to include(
-      'id', 'name', 'description', 'minimum_quantity', 'current_stock'
+      'id', 'name', 'description', 'minimum_quantity', 'stock_quantity'
     )
   end
 
@@ -27,5 +29,23 @@ RSpec.describe ItemSerializer, type: :serializer do
     expect(serialization.keys).to include(
       'category', 'company', 'stocks'
     )
+  end
+
+  describe '属性の値' do
+    it '基本情報が正しくシリアライズされること' do
+      expect(serialization['name']).to eq(item.name)
+      expect(serialization['stock_quantity']).to eq(item.stock_quantity)
+    end
+
+    it '関連IDが正しくシリアライズされること' do
+      expect(serialization['category_id']).to eq(item.category_id)
+      expect(serialization['company_id']).to eq(item.company_id)
+    end
+  end
+
+  it '関連モデルが正しくシリアライズされること' do
+    expect(serialization['category']).to be_present
+    expect(serialization['company']).to be_present
+    expect(serialization['stocks']).to eq([])
   end
 end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -186,6 +186,10 @@ components:
               type: string
               description: 消耗品の説明
               maxLength: 1000
+            stock_quantity:
+              type: integer
+              description: 現在の在庫数
+              minimum: 0
             minimum_quantity:
               type: integer
               description: 最小在庫数
@@ -756,5 +760,43 @@ paths:
           $ref: "#/components/responses/Success"
         "403":
           $ref: "#/components/responses/Error"
+        "422":
+          $ref: "#/components/responses/Error"
+
+  /api/v1/companies/{company_id}/items/{id}/update_stock:
+    parameters:
+      - $ref: "#/components/parameters/CompanyId"
+      - $ref: "#/components/parameters/ResourceId"
+
+    patch:
+      tags: [Items]
+      summary: 在庫数の更新
+      description: |
+        消耗品の在庫数を更新します
+        - 在庫の増減操作を記録します
+        - 在庫履歴も同時に作成されます
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                stock:
+                  type: object
+                  properties:
+                    quantity:
+                      type: integer
+                      description: 数量
+                    operation_type:
+                      type: string
+                      enum: [addition, subtraction]
+                      description: 操作種別（addition:入庫、subtraction:出庫）
+                  required:
+                    - quantity
+                    - operation_type
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
         "422":
           $ref: "#/components/responses/Error"

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -194,10 +194,6 @@ components:
               type: integer
               description: 最小在庫数
               minimum: 0
-            current_stock:
-              type: integer
-              description: 現在の在庫数
-              minimum: 0
             unit:
               type: string
               description: 単位
@@ -238,10 +234,6 @@ components:
             minimum_quantity:
               type: integer
               description: 最小在庫数
-              minimum: 0
-            current_stock:
-              type: integer
-              description: 現在の在庫数
               minimum: 0
             unit:
               type: string


### PR DESCRIPTION
## 概要
- 消耗品（Item）モデルの在庫管理フィールドを整理
- 在庫数更新のためのAPIエンドポイントを実装

## 変更内容
### モデル
- Itemモデルのフィールドを整理
  - `current_stock`を削除
  - `stock_quantity`: 現在の在庫数を追加

### API
- 在庫数更新エンドポイントの実装
  - パス: `/api/v1/companies/{company_id}/items/{id}/update_stock`
  - メソッド: PATCH
  - 在庫の増減を記録
  - 操作履歴の保存

### テスト
- モデルスペックの追加
- リクエストスペックの追加
- バリデーションテストの追加

## レビューポイント
- 在庫数更新のロジック
- バリデーションの妥当性
- テストケースの網羅性