### PR TITLE
chore: .viteディレクトリをgit管理対象から除外

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.vite


### PR DESCRIPTION
## 変更内容
- フロントエンドのディレクトリ構造を整理
- .viteディレクトリをgit管理対象から除外